### PR TITLE
MEX-6: Address should have fields "community" and "directions"

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/deploy/bundle/mexico/MexicoAddressBundle.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/deploy/bundle/mexico/MexicoAddressBundle.java
@@ -1,0 +1,39 @@
+package org.openmrs.module.pihcore.deploy.bundle.mexico;
+
+import org.openmrs.module.addresshierarchy.AddressField;
+import org.openmrs.module.pihcore.deploy.bundle.AddressBundle;
+import org.openmrs.module.pihcore.deploy.bundle.AddressComponent;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class MexicoAddressBundle extends AddressBundle {
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+
+    @Override
+    public List<AddressComponent> getAddressComponents() {
+        List<AddressComponent> l = new ArrayList<AddressComponent>();
+        l.add(new AddressComponent(AddressField.CITY_VILLAGE, "Comunidad", 40, null, false));
+        l.add(new AddressComponent(AddressField.ADDRESS_1, "Dirección", 80, null, false));
+        return l;
+    }
+
+    @Override
+    public List<String> getLineByLineFormat() {
+        List<String> l = new ArrayList<String>();
+        l.add("address1");
+        l.add("cityVillage");
+        return l;
+    }
+
+    @Override
+    public String getAddressHierarchyEntryPath() {
+        return "addresshierarchy/mexico_address_hierarchy_entries_1.csv";
+    }
+}

--- a/api/src/main/java/org/openmrs/module/pihcore/deploy/bundle/mexico/MexicoMetadataBundle.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/deploy/bundle/mexico/MexicoMetadataBundle.java
@@ -14,8 +14,9 @@ import java.util.Map;
 
 @Component
 @Requires({ PihCoreMetadataBundle.class,
-        MexicoLocationsBundle.class,
-        MexicoPatientIdentifierTypeBundle.class} )
+            MexicoAddressBundle.class,
+            MexicoLocationsBundle.class,
+            MexicoPatientIdentifierTypeBundle.class} )
 public class MexicoMetadataBundle extends AbstractMetadataBundle {
     public static final String DEFAULT_LOCALE = "es";
     public static final String ALLOWED_LOCALES = "es, en";

--- a/api/src/main/resources/addresshierarchy/mexico_address_hierarchy_entries_1.csv
+++ b/api/src/main/resources/addresshierarchy/mexico_address_hierarchy_entries_1.csv
@@ -1,0 +1,137 @@
+12 de Abril
+3 de mayo
+5 de Mayo
+7 de Octubre
+Aguatibia
+Ampliación Laguna
+Ángel Díaz
+Arenal
+Argentina
+Barrio Limón
+Bejucal
+Belisario
+Buenos Aires
+Cacahuatán
+Campo Aéreo
+Capitán
+Cerro Perote
+Chicomuselo
+Comalapa
+Comitán
+Concepción Pinada
+Cruz Grande
+Cruz de Piedra
+Delicias
+El Limón
+El Porvenir
+El Retiro
+El Tesoro
+Escobillal
+Escuintla
+Floresta
+Foranea
+Frailesca
+Galeana
+Garitas
+Guatemala
+Guayabal
+Guerrero
+Honduras
+Independencia
+Jaltenango
+Jerusalén
+La Aleluya
+La Cascada
+La Laguna
+La Lucha
+La Paz
+La Pinada
+La loma
+Laguna Toquian
+Laguna del Cofre
+Lagunita
+Las Cruces
+Las Flores
+Las Garitas
+Las Moras
+Las Nubes
+Las Pilas
+Las Salinas
+Letrero
+Libertad 2
+Llano grande
+Loma Bonita
+Loma Gracias a Dios
+Los Cimientos
+Los Laureles
+Los Pinos
+Madero
+Mal Paso
+Manguito
+Mapastepec
+Matasanito
+Matasano
+Matazano
+Montebello
+Montecristo
+Monterrey
+Motozintla
+Naranjo
+Nueva Argentina
+Nueva Francia
+Nueva Independencia
+Nueva Jerusalem
+Nueva Libertad
+Nueva Lucha
+Nuevo Laredo
+Ojo de Agua
+Otro
+Pablo Galeana
+Palenque
+Palenque 1
+Palenque 2
+Palestina
+Palmar Grande
+Palmarcillo
+Paraíso
+Parralito
+Piedra Parada
+Piedra Blanca
+Plan Alta
+Plan Baja
+Plan de Ayala
+Plan de Ayutla
+Plan de la Libertad
+Puerto Madero
+Puerto Rico
+Querétaro
+Rancho Bonito
+Reforma
+Salvador Urbina
+San Antonio la Pinada
+San Cristóbal de las Casas
+San José
+San Nicolas
+San Rafael
+Santa Isabel
+Santa María
+Santa Rita
+Santa Rosa
+Siltepec
+Soledad
+Tapachula
+Temporal
+Tesoro
+Tierra Blanca
+Toquian Grande
+Tuxtla Gutiérrez
+Vega de Guerrero
+Vega de Juárez
+Vega de Rosario
+Vicente Guerrero
+Villa Moras
+Villa Morelos
+Villanueva
+Violeta
+Vista Alegre
+Zapata


### PR DESCRIPTION
https://tickets.pih-emr.org/browse/MEX-6

This adds address hierarchy entries; changes address format.

This includes "Otro" (Other) as an option for Community.

This also seems to add a field called something like "Rapidly search for an address" that seems quite redundant with the Community field itself. Eventually we'll probably want to get rid of that.