### PR TITLE
Align template icons (expand, edit) on visit page

### DIFF
--- a/omod/src/main/webapp/pages/visit/templates/sections/defaultPlanSectionActions.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/sections/defaultPlanSectionActions.gsp
@@ -1,4 +1,4 @@
-<div class="pull-right">
+<div class="float-right">
     <a class="expand-encounter" ng-show="canExpand()" ng-click="expand()"><i class="icon-caret-right"></i></a>
     <a class="contract-encounter" ng-show="canContract()" ng-click="contract()"><i class="icon-caret-down"></i></a>
     <a class="edit-encounter" ng-show="canEdit()" ng-click="edit()"><i class="icon-pencil"></i></a>

--- a/omod/src/main/webapp/pages/visit/templates/sections/defaultPlanSectionActions.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/sections/defaultPlanSectionActions.gsp
@@ -1,6 +1,11 @@
-<a class="expand-encounter" ng-show="canExpand()" ng-click="expand()"><i class="icon-caret-right"></i></a>
-<a class="contract-encounter" ng-show="canContract()" ng-click="contract()"><i class="icon-caret-down"></i></a>
-<a class="edit-encounter" ng-show="canEdit()" ng-click="edit()"><i class="icon-pencil"></i></a>
-<a class="edit-encounter" ng-show="!canEdit()"><i class="icon-delete-blank"></i></a>
-<a class="delete-encounter" ng-show="(encounter.obs | byConcept:Concepts.prescriptionConstruct).length > 0" ng-click="printPrescriptions()"><i class="icon-print" title="${ ui.message('pihcore.visitNote.printPrescriptions') }"></i></a>
-<a class="delete-encounter" ng-show="(encounter.obs | byConcept:Concepts.prescriptionConstruct).length < 1"><i class="icon-delete-blank"></i></a>
+<div class="pull-right">
+    <a class="expand-encounter" ng-show="canExpand()" ng-click="expand()"><i class="icon-caret-right"></i></a>
+    <a class="contract-encounter" ng-show="canContract()" ng-click="contract()"><i class="icon-caret-down"></i></a>
+    <a class="edit-encounter" ng-show="canEdit()" ng-click="edit()"><i class="icon-pencil"></i></a>
+    <a class="edit-encounter" ng-show="!canEdit()"><i class="icon-delete-blank"></i></a>
+    <a class="delete-encounter" ng-show="(encounter.obs | byConcept:Concepts.prescriptionConstruct).length > 0"
+       ng-click="printPrescriptions()"><i class="icon-print"
+                                          title="${ui.message('pihcore.visitNote.printPrescriptions')}"></i></a>
+    <a class="delete-encounter" ng-show="(encounter.obs | byConcept:Concepts.prescriptionConstruct).length < 1"><i
+            class="icon-delete-blank"></i></a>
+</div>

--- a/omod/src/main/webapp/pages/visit/templates/sections/defaultSectionActions.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/sections/defaultSectionActions.gsp
@@ -1,4 +1,4 @@
-<div class="pull-right">
+<div class="float-right">
     <a class="expand-encounter" ng-show="canExpand()" ng-click="expand()"><i class="icon-caret-right"></i></a>
     <a class="contract-encounter" ng-show="canContract()" ng-click="contract()"><i class="icon-caret-down"></i></a>
     <a class="edit-encounter" ng-show="canEdit()" ng-click="edit()"><i class="icon-pencil"></i></a>

--- a/omod/src/main/webapp/pages/visit/templates/sections/defaultSectionActions.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/sections/defaultSectionActions.gsp
@@ -1,6 +1,8 @@
-<a class="expand-encounter" ng-show="canExpand()" ng-click="expand()"><i class="icon-caret-right"></i></a>
-<a class="contract-encounter" ng-show="canContract()" ng-click="contract()"><i class="icon-caret-down"></i></a>
-<a class="edit-encounter" ng-show="canEdit()" ng-click="edit()"><i class="icon-pencil"></i></a>
-<a class="edit-encounter" ng-show="!canEdit()"><i class="icon-delete-blank"></i></a>
-<a class="delete-encounter"><i class="icon-delete-blank"></i></a>
+<div class="pull-right">
+    <a class="expand-encounter" ng-show="canExpand()" ng-click="expand()"><i class="icon-caret-right"></i></a>
+    <a class="contract-encounter" ng-show="canContract()" ng-click="contract()"><i class="icon-caret-down"></i></a>
+    <a class="edit-encounter" ng-show="canEdit()" ng-click="edit()"><i class="icon-pencil"></i></a>
+    <a class="edit-encounter" ng-show="!canEdit()"><i class="icon-delete-blank"></i></a>
+    <a class="delete-encounter"><i class="icon-delete-blank"></i></a>
+</div>
 


### PR DESCRIPTION
I added a div in the appropriate files which included a class (pull-rigth) allowing to align the actions section on the right.
please accept my pull request.
@mogoodrich @lnball @mseaton 