### PR TITLE
Create metadata for OVC program

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/PihCoreConstants.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/PihCoreConstants.java
@@ -84,6 +84,9 @@ public class PihCoreConstants {
     public static final String MALNUTRITION_PROGRAM_CONCEPT_UUID = "3ce1e560-26fe-102b-80cb-0017a47871b2";  // PIH:2234, HUM NCD
     public static final String MALNUTRITION_PROGRAM_OUTCOMES_CONCEPT_UUID = "73eb05c2-e4be-4d82-bcad-ffec1be67d01";  // PIH:11505
 
+    public static final String OVC_PROGRAM_CONCEPT_UUID = "3ce1e560-26fe-102b-80cb-0017a47871b2";  // PIH:OVC PROGRAM, HUM NCD
+    public static final String OVC_PROGRAM_OUTCOMES_CONCEPT_UUID = "73eb05c2-e4be-4d82-bcad-ffec1be67d01";  // PIH:11505
+
     public static final String MCH_PROGRAM_CONCEPT_UUID = "159937AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";  // PIH:10347, Haiti HIV, HUM Clinical Concepts, PIH Maternal Child Health, Liberia Concepts
     public static final String MCH_PROGRAM_OUTCOME_CONCEPT_UUID = "cd4e30b1-9935-4b30-9de8-b56e057c541d";  // PIH:11728, PIH Maternal Child Health
     public static final String GROUP_CARE_UUID = "f58e875f-de07-4cfd-8fc7-3e70b7390ecc";

--- a/api/src/main/java/org/openmrs/module/pihcore/config/Components.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/config/Components.java
@@ -25,6 +25,7 @@ public class Components {
         public static final String VACCINATION_FORM = "vaccination";
         public static final String ZIKA = "zika";  // program
         public static final String COVID19 = "covid19";
+        public static final String OVC = "ovc";  // program and forms
         public static final String ANC_PROGRAM = "ancProgram";  // needs ANCProgramBundle, used by CES
         public static final String ASTHMA_PROGRAM = "asthmaProgram";  // needs AsthmaProgramBundle, used by CES
         public static final String MENTAL_HEALTH= "mentalHealth";  // mentalHealthForm + mentalHealthProgram

--- a/api/src/main/java/org/openmrs/module/pihcore/deploy/bundle/core/EncounterTypeBundle.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/deploy/bundle/core/EncounterTypeBundle.java
@@ -58,6 +58,8 @@ public class EncounterTypeBundle extends AbstractMetadataBundle {
         install(EncounterTypes.COVID19_INTAKE);
         install(EncounterTypes.COVID19_FOLLOWUP);
         install(EncounterTypes.COVID19_DISCHARGE);
+        install(EncounterTypes.OVC_INTAKE);
+        install(EncounterTypes.OVC_FOLLOWUP);
 
         uninstall(possible(EncounterType.class, AttachmentsConstants.ENCOUNTER_TYPE_UUID), "not used");
         uninstall(possible(EncounterType.class, EncounterTypes.MEXICO_CLINIC_VISIT.uuid()), "replaced with Mexico Consult");

--- a/api/src/main/java/org/openmrs/module/pihcore/deploy/bundle/core/program/OVCProgramBundle.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/deploy/bundle/core/program/OVCProgramBundle.java
@@ -1,0 +1,14 @@
+package org.openmrs.module.pihcore.deploy.bundle.core.program;
+
+import org.openmrs.module.metadatadeploy.bundle.AbstractMetadataBundle;
+import org.openmrs.module.pihcore.metadata.core.program.OVCProgram;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OVCProgramBundle extends AbstractMetadataBundle {
+
+    @Override
+    public void install() throws Exception {
+        install(OVCProgram.OVC);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/pihcore/deploy/bundle/core/program/PihProgramsBundle.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/deploy/bundle/core/program/PihProgramsBundle.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
         MentalHealthProgramBundle.class,
         MCHProgramBundle.class,  // requires PIH Maternal Child Health MDS package
         NCDProgramBundle.class,
+        OVCProgramBundle.class,
         OncologyProgramBundle.class,
         ZikaProgramBundle.class
 })

--- a/api/src/main/java/org/openmrs/module/pihcore/metadata/core/EncounterTypes.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/metadata/core/EncounterTypes.java
@@ -322,13 +322,13 @@ public class EncounterTypes {
 	public static EncounterTypeDescriptor OVC_INTAKE  = new EncounterTypeDescriptor() {
 		public String uuid() { return "651d4359-4463-4e52-8fde-e62876f90792"; }
 		public String name() { return "OVC Intake"; }
-		public String description() { return "OVC intake form"; }
+		public String description() { return "USAID Orphans and Vulnerable Children (OVC) program intage"; }
 	};
 
 	public static EncounterTypeDescriptor OVC_FOLLOWUP  = new EncounterTypeDescriptor() {
 		public String uuid() { return "f8d426fd-132a-4032-93da-1213c30e2b74"; }
 		public String name() { return "OVC Follow-up"; }
-		public String description() { return "OVC follow-up form"; }
+		public String description() { return "USAID Orphans and Vulnerable Children (OVC) program follow-up"; }
 	};
 
 	// the following have been deprecated and should eventually be able to be removed--they were encounter types we were developing for the new visit note

--- a/api/src/main/java/org/openmrs/module/pihcore/metadata/core/EncounterTypes.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/metadata/core/EncounterTypes.java
@@ -319,6 +319,18 @@ public class EncounterTypes {
 		public String description() { return "COVID-19 Discharge note at health facility"; }
 	};
 
+	public static EncounterTypeDescriptor OVC_INTAKE  = new EncounterTypeDescriptor() {
+		public String uuid() { return "651d4359-4463-4e52-8fde-e62876f90792"; }
+		public String name() { return "OVC Intake"; }
+		public String description() { return "OVC intake form"; }
+	};
+
+	public static EncounterTypeDescriptor OVC_FOLLOWUP  = new EncounterTypeDescriptor() {
+		public String uuid() { return "f8d426fd-132a-4032-93da-1213c30e2b74"; }
+		public String name() { return "OVC Follow-up"; }
+		public String description() { return "OVC follow-up form"; }
+	};
+
 	// the following have been deprecated and should eventually be able to be removed--they were encounter types we were developing for the new visit note
 	// but have decided to use a single encounter for the visit (with the primary care visit encounter type)
 

--- a/api/src/main/java/org/openmrs/module/pihcore/metadata/core/program/OVCProgram.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/metadata/core/program/OVCProgram.java
@@ -1,0 +1,24 @@
+package org.openmrs.module.pihcore.metadata.core.program;
+
+import org.openmrs.module.metadatadeploy.descriptor.ProgramDescriptor;
+import org.openmrs.module.metadatadeploy.descriptor.ProgramWorkflowDescriptor;
+import org.openmrs.module.metadatadeploy.descriptor.ProgramWorkflowStateDescriptor;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.openmrs.module.pihcore.PihCoreConstants.*;
+
+public class OVCProgram {
+
+    public static ProgramDescriptor OVC = new ProgramDescriptor() {
+        public String conceptUuid() { return OVC_PROGRAM_CONCEPT_UUID; }
+        public String name() { return "OVC"; }
+        public String description() { return "USAID orphans and vulnerable children program"; }
+        public String uuid() { return "b1cb1fc1-5190-4f7a-af08-48870975dafc"; }
+
+        @Override public String outcomesConceptUuid()  { return OVC_PROGRAM_OUTCOMES_CONCEPT_UUID; }
+    };
+
+}


### PR DESCRIPTION
This creates a stub for the OVC program, as well as the encounter types for the intake and follow-up forms.

Relates to
[UHM-4979 OVC Intake form](https://pihemr.atlassian.net/browse/UHM-4979)
[UHM-4986 OVC Program config](https://pihemr.atlassian.net/browse/UHM-4986)