### PR TITLE
Don't use LATEST version for config repos

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -72,7 +72,7 @@
 						<configuration>
 							<groupId>org.pih.openmrs</groupId>
 							<artifactId>openmrs-config-ces</artifactId>
-                            <version>1.9.0-SNAPSHOT</version>
+                            <version>1.11.0-SNAPSHOT</version>
 							<packageName>org.openmrs.module.pihcore</packageName>
 							<className>CesConfigConstants</className>
 						</configuration>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -72,7 +72,7 @@
 						<configuration>
 							<groupId>org.pih.openmrs</groupId>
 							<artifactId>openmrs-config-ces</artifactId>
-                            <version>LATEST</version>
+                            <version>1.9.0-SNAPSHOT</version>
 							<packageName>org.openmrs.module.pihcore</packageName>
 							<className>CesConfigConstants</className>
 						</configuration>
@@ -86,7 +86,7 @@
 						<configuration>
 							<groupId>org.pih.openmrs</groupId>
 							<artifactId>openmrs-config-ses</artifactId>
-                            <version>LATEST</version>
+                            <version>1.0.0-SNAPSHOT</version>
 							<packageName>org.openmrs.module.pihcore</packageName>
 							<className>SesConfigConstants</className>
 						</configuration>
@@ -100,7 +100,7 @@
 						<configuration>
 							<groupId>org.pih.openmrs</groupId>
 							<artifactId>openmrs-config-pihliberia</artifactId>
-                            <version>LATEST</version>
+                            <version>1.2.1-SNAPSHOT</version>
 							<packageName>org.openmrs.module.pihcore</packageName>
 							<className>LiberiaConfigConstants</className>
 						</configuration>
@@ -114,7 +114,7 @@
 						<configuration>
 							<groupId>org.pih.openmrs</groupId>
 							<artifactId>openmrs-config-pihsl</artifactId>
-                            <version>LATEST</version>
+                            <version>1.7.0-SNAPSHOT</version>
 							<packageName>org.openmrs.module.pihcore</packageName>
 							<className>SierraLeoneConfigConstants</className>
 						</configuration>
@@ -128,7 +128,7 @@
 						<configuration>
 							<groupId>org.pih.openmrs</groupId>
 							<artifactId>openmrs-config-zl</artifactId>
-                            <version>LATEST</version>
+                            <version>1.25.0-SNAPSHOT</version>
 							<packageName>org.openmrs.module.pihcore</packageName>
 							<className>ZlConfigConstants</className>
 						</configuration>


### PR DESCRIPTION
Use the explicit snapshot versions. These are kept up to date by the release job: https://github.com/PIH/openmrs-config-pihemr/pull/235 . The latter commit on this PR was made by the release job.