### PR TITLE
UHM-5404 - Adds 2 features to support this ticket.

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/config/Config.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/config/Config.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.pihcore.config;
 
 import org.codehaus.jackson.node.ArrayNode;
+import org.openmrs.module.appframework.domain.Extension;
 import org.openmrs.module.pihcore.config.registration.AddressConfigDescriptor;
 import org.openmrs.module.pihcore.config.registration.BiometricsConfigDescriptor;
 import org.openmrs.module.pihcore.config.registration.RegistrationConfigDescriptor;
@@ -144,5 +145,9 @@ public class Config {
 
     public ArrayNode getFindPatientColumnConfig() {
         return descriptor.getFindPatientColumnConfig();
+    }
+
+    public List<Extension> getExtensions() {
+        return descriptor.getExtensions();
     }
 }

--- a/api/src/main/java/org/openmrs/module/pihcore/config/ConfigDescriptor.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/config/ConfigDescriptor.java
@@ -1,15 +1,16 @@
 package org.openmrs.module.pihcore.config;
 
+import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.node.ArrayNode;
+import org.openmrs.module.appframework.domain.Extension;
+import org.openmrs.module.pihcore.config.registration.AddressConfigDescriptor;
+import org.openmrs.module.pihcore.config.registration.BiometricsConfigDescriptor;
+import org.openmrs.module.pihcore.config.registration.RegistrationConfigDescriptor;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import org.codehaus.jackson.annotate.JsonProperty;
-import org.codehaus.jackson.node.ArrayNode;
-import org.openmrs.module.pihcore.config.registration.AddressConfigDescriptor;
-import org.openmrs.module.pihcore.config.registration.BiometricsConfigDescriptor;
-import org.openmrs.module.pihcore.config.registration.RegistrationConfigDescriptor;
 
 /**
  * Object that encapsulates the options that can be configured on a per-installation basis
@@ -101,6 +102,9 @@ public class ConfigDescriptor {
 
     @JsonProperty
     private ArrayNode findPatientColumnConfig;
+
+    @JsonProperty
+    private List<Extension> extensions;
 
     public String getWelcomeMessage() {
         return welcomeMessage;
@@ -305,5 +309,16 @@ public class ConfigDescriptor {
 
     public void setFindPatientColumnConfig(ArrayNode findPatientColumnConfig) {
         this.findPatientColumnConfig = findPatientColumnConfig;
+    }
+
+    public List<Extension> getExtensions() {
+        if (extensions == null) {
+            extensions = new ArrayList<>();
+        }
+        return extensions;
+    }
+
+    public void setExtensions(List<Extension> extensions) {
+        this.extensions = extensions;
     }
 }

--- a/omod/src/main/java/org/openmrs/module/pihcore/page/controller/PatientPageController.java
+++ b/omod/src/main/java/org/openmrs/module/pihcore/page/controller/PatientPageController.java
@@ -1,0 +1,62 @@
+package org.openmrs.module.pihcore.page.controller;
+
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifier;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.api.PatientService;
+import org.openmrs.ui.framework.UiUtils;
+import org.openmrs.ui.framework.annotation.SpringBean;
+import org.openmrs.ui.framework.converter.util.ConversionUtil;
+import org.openmrs.ui.framework.page.PageModel;
+import org.openmrs.ui.framework.page.Redirect;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class PatientPageController {
+
+    public Object controller(PageModel model, UiUtils ui,
+                      @RequestParam(required = true, value = "patientId") String patientId,
+                      @RequestParam(required = false, value = "identifierType") String identifierType,
+                      @RequestParam(required = false, value = "dashboard") String dashboard,
+                      @SpringBean("patientService") PatientService patientService) throws IOException {
+
+        Patient p;
+        if (identifierType == null) {
+            if (ConversionUtil.onlyDigits(patientId)) {
+                p = patientService.getPatient(Integer.valueOf(patientId));
+            }
+            else {
+                p = patientService.getPatientByUuid(patientId);
+            }
+            if (p == null) {
+                throw new IllegalArgumentException("Unable to find patient with patientId: " + patientId);
+            }
+        }
+        else {
+            PatientIdentifierType piType = patientService.getPatientIdentifierTypeByUuid(identifierType);
+            List<PatientIdentifier> identifiers = patientService.getPatientIdentifiers(patientId, Arrays.asList(piType), null, null, null);
+            Set<Patient> patientsFound = new HashSet<>();
+            for (PatientIdentifier pi : identifiers) {
+                patientsFound.add(pi.getPatient());
+            }
+            if (patientsFound.size() == 1) {
+                p = patientsFound.iterator().next();
+            }
+            else {
+                throw new IllegalArgumentException("Found " + patientsFound.size() + " with " + identifierType + " = " + patientId);
+            }
+        }
+
+        if ("registration".equalsIgnoreCase(dashboard)) {
+            return new Redirect("registrationapp", "registrationSummary", "patientId=" + p.getUuid());
+        }
+        else {
+            return new Redirect("coreapps", "clinicianfacing/patient", "patientId=" + p.getUuid() + "&dashboard=" + dashboard);
+        }
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/pihcore/page/controller/PatientPageController.java
+++ b/omod/src/main/java/org/openmrs/module/pihcore/page/controller/PatientPageController.java
@@ -17,6 +17,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * The purpose of this page controller is to provide a means to link to an existing patient dashboard
+ * page from a different EMR instance, where a patient identifier is shared between instances rather than
+ * a uuid or primary key identifier.  The initial use case is to support linking into the patients HIV dashboard
+ * in a cloud-based HIV EMR for Haiti from a facility-based primary care EMR, where the common identifier is a
+ * specific patient identifier type.
+ */
 public class PatientPageController {
 
     public Object controller(PageModel model, UiUtils ui,


### PR DESCRIPTION
UHM-5404 - Adds 2 features to support this ticket.  1. Adds a new page controller that supports passing a patient identifier and type, and a particular set of configurations, to open a patient dashboard for a patient with that identifier.  2.  Adds the ability to add arbitrary extensions via PIH config as an alternative to doing this programmatically in the CALF.