### PR TITLE
Localized formatting of dates in the visit note

### DIFF
--- a/omod/src/main/webapp/pages/visit/templates/encounters/defaultEncounterHeading.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/encounters/defaultEncounterHeading.gsp
@@ -4,10 +4,10 @@
     </div>
     <div class="col-4 text-right">
         <span class="date-span">
-            <i class="icon-calendar"></i>{{ encounter.encounterDatetime | serverDate:DatetimeFormats.date }}
+            <i class="icon-calendar"></i>{{ encounter.encounterDatetime | toLocaleDateString:DatetimeFormats.dateLocalized }}
         </span>
         <span class="time-span">
-            <i class="icon-time"></i>{{ encounter.encounterDatetime | serverDate:DatetimeFormats.time }}
+            <i class="icon-time"></i>{{ encounter.encounterDatetime | toLocaleTimeString:DatetimeFormats.timeLocalized }}
         </span>
     </div>
 </div>

--- a/omod/src/main/webapp/pages/visit/templates/encounters/vitalsEncounterHeading.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/encounters/vitalsEncounterHeading.gsp
@@ -4,10 +4,10 @@
     </div>
     <div class="col-4 text-right">
         <span class="date-span">
-            <i class="icon-calendar"></i>{{ encounter.encounterDatetime | serverDate:DatetimeFormats.date }}
+            <i class="icon-calendar"></i>{{ encounter.encounterDatetime | toLocaleDateString:DatetimeFormats.dateLocalized }}
         </span>
         <span class="time-span">
-            <i class="icon-time"></i>{{ encounter.encounterDatetime | serverDate:DatetimeFormats.time }}
+            <i class="icon-time"></i>{{ encounter.encounterDatetime | toLocaleTimeString:DatetimeFormats.timeLocalized }}
         </span>
     </div>
 </div>

--- a/omod/src/main/webapp/pages/visit/templates/visitDetails.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/visitDetails.gsp
@@ -11,8 +11,8 @@
 <div class="visit-dates">
     <span>
         <i class="icon-time small"></i>
-        {{ visit.startDatetime | serverDate:DatetimeFormats.date }}
-        <span ng-show="visit.stopDatetime">- {{ visit.stopDatetime | serverDate:DatetimeFormats.date  }}</span>
+        {{ visit.startDatetime | toLocaleDateString:DatetimeFormats.dateLocalized }}
+        <span ng-show="visit.stopDatetime">- {{ visit.stopDatetime | toLocaleDateString:DatetimeFormats.dateLocalized  }}</span>
         <span ng-hide="visit.stopDatetime" class="lozenge active">
             (${ ui.message("uicommons.active") })
         </span>

--- a/omod/src/main/webapp/resources/scripts/visit/constants.js
+++ b/omod/src/main/webapp/resources/scripts/visit/constants.js
@@ -1,7 +1,12 @@
 angular.module('constants', [])
     .value('DatetimeFormats', {
         date: "d-MMM-yy",
+        dateLocalized: { year: 'numeric', month: 'short', day: 'numeric' },
         time: "hh:mm a",
+        // TODO: fix timeLocalized:
+        //   'hour12' override is necessary because we're using `fr` in Haiti instead of `fr_HT`.
+        //   This override will prevent time from displaying correctly in places that use a 24 hour clock.
+        timeLocalized: { hour: '2-digit', minute: '2-digit', hour12: true },
         datetime: "d-MMM-yy (hh:mm a)"
     })
 


### PR DESCRIPTION
Depends on https://github.com/openmrs/openmrs-module-uicommons/pull/98

English:
![Screenshot from 2021-11-05 16-06-05](https://user-images.githubusercontent.com/1031876/140587810-fb2eec63-841a-44d3-a9de-881fb3e78786.png)

Spanish:
![Screenshot from 2021-11-05 16-05-46](https://user-images.githubusercontent.com/1031876/140587818-1b84856b-ab6c-46af-a08d-f2362c4f7a58.png)

French:
![Screenshot from 2021-11-05 16-06-20](https://user-images.githubusercontent.com/1031876/140587826-684a1436-d44e-4093-a5d9-ec22d9dc092b.png)

Still displays in English for Haitian, but that's not actually a regression, because these have always displayed in English. They'll start displaying in French format next year, pending a Unicode update.
