### PR TITLE
change parameters so that PIH Core "pihcore.started" doesn't get set …

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/PihCoreActivator.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/PihCoreActivator.java
@@ -71,7 +71,7 @@ public class PihCoreActivator extends BaseModuleActivator implements DaemonToken
         }
         catch (Exception e) {
             Module mod = ModuleFactory.getModuleById("pihcore");
-            ModuleFactory.stopModule(mod, false, false);
+            ModuleFactory.stopModule(mod, true, true);
             throw new RuntimeException("An error occurred while starting the pihcore module", e);
         }
     }


### PR DESCRIPTION
…to "false" on failed startup