### PR TITLE
SL-414, display drug orders concepts in the encounter header

### DIFF
--- a/omod/src/main/webapp/pages/visit/templates/sections/primaryCarePlanSectionHeading.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/sections/primaryCarePlanSectionHeading.gsp
@@ -19,5 +19,8 @@
     <span ng-repeat="obs in encounter.obs | byConcept:Concepts.prescriptionConstruct">
         {{ (obs | groupMember:Concepts.medicationOrders).value.concept | omrsDisplay }}{{ \$last ? "" : "," }}
     </span>
+    <span ng-repeat="drugOrder in encounter.orders | byOrderType:OrderTypes.drugOrder ">
+        {{ drugOrder.concept | omrsDisplay }}{{ \$last ? "" : "," }}
+    </span>
 </span>
 <span ng-show="showEncounterDetails" ng-include="'templates/showEncounterDetails.page'" />

--- a/omod/src/main/webapp/resources/scripts/visit/constants.js
+++ b/omod/src/main/webapp/resources/scripts/visit/constants.js
@@ -500,6 +500,11 @@ angular.module('constants', [])
             uuid: "4f10ad1a-ec49-48df-98c7-1391c6ac7f05"
         }
     })
+    .value('OrderTypes', {
+        drugOrder: {
+            uuid: "131168f4-15f5-102d-96e4-000c29c2a5d7"
+        }
+    })
     .value('VisitTypes', {
         clinicalOrHospitalVisit: {
             uuid: "f01c54cb-2225-471a-9cd5-d348552c337c"

--- a/omod/src/main/webapp/resources/scripts/visit/filters.js
+++ b/omod/src/main/webapp/resources/scripts/visit/filters.js
@@ -118,6 +118,18 @@ angular.module("filters", [ "uicommons.filters", "constants", "encounterTypeConf
         }
     }])
 
+    .filter("byOrderType", [function() {
+        return function(listOfOrders, orderType, justOne) {
+            var f = justOne ? _.find : _.filter;
+            return f(listOfOrders, function(candidate) {
+                if (!candidate.orderType) {
+                    return false;
+                }
+                return candidate.orderType.uuid === orderType.uuid;
+            });
+        }
+    }])
+
     .filter("primaryCareExam", ["Concepts", "PrimaryCareExamConcepts", function (Concepts, PrimaryCareExamConcepts) {
         return function(listOfObs) {
             return _.filter(listOfObs, function (candidate) {

--- a/omod/src/main/webapp/resources/scripts/visit/visit.js
+++ b/omod/src/main/webapp/resources/scripts/visit/visit.js
@@ -83,8 +83,8 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
         }
     }])
 
-    .directive("encounter", [ "Encounter", "Concepts", "EncounterRoles", "DatetimeFormats", "SessionInfo", "EncounterTypeConfig", "$http", "$sce", "$filter",
-        function(Encounter, Concepts, EncounterRoles, DatetimeFormats, SessionInfo, EncounterTypeConfig, $http, $sce, $filter) {
+    .directive("encounter", [ "Encounter", "Concepts", "OrderTypes", "EncounterRoles", "DatetimeFormats", "SessionInfo", "EncounterTypeConfig", "$http", "$sce", "$filter",
+        function(Encounter, Concepts, OrderTypes, EncounterRoles, DatetimeFormats, SessionInfo, EncounterTypeConfig, $http, $sce, $filter) {
             return {
                 restrict: "E",
                 scope: {
@@ -102,6 +102,7 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
 
                     $scope.DatetimeFormats = DatetimeFormats;
                     $scope.Concepts = Concepts;
+                    $scope.OrderTypes = OrderTypes;
                     $scope.EncounterRoles = EncounterRoles;
                     $scope.session = SessionInfo.get();
                     $scope.encounterState = $scope.selected ? "long" : (config ? config.defaultState : "short");
@@ -236,8 +237,8 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
             }
     }])
 
-    .directive("encounterSection", [ "Concepts", "DatetimeFormats", "SessionInfo", "$http", "$sce", "$timeout", "initialRouterState",
-        function(Concepts, DatetimeFormats, SessionInfo, $http, $sce, $timeout, initialRouterState) {
+    .directive("encounterSection", [ "Concepts", "OrderTypes", "DatetimeFormats", "SessionInfo", "$http", "$sce", "$timeout", "initialRouterState",
+        function(Concepts, OrderTypes, DatetimeFormats, SessionInfo, $http, $sce, $timeout, initialRouterState) {
             return {
                 restrict: "E",
                 scope: {
@@ -250,6 +251,7 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
 
                     $scope.DatetimeFormats = DatetimeFormats;
                     $scope.Concepts = Concepts;
+                    $scope.OrderTypes = OrderTypes;
                     $scope.state = 'short';
                     $scope.sectionLoaded = false;
                     $scope.session = SessionInfo.get();
@@ -509,10 +511,10 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
 
     .controller("VisitController", [ "$scope", "$rootScope", "$translate","$http", "Visit", "$state",
         "$timeout", "$filter", "ngDialog", "Encounter", "EncounterTypeConfig", "AppFrameworkService",
-        "visitUuid", "visitTypeUuid", "encounterTypeUuid", "suppressActions", "patientUuid", "encounterUuid", "locale", "currentSection", "goToNext", "initialRouterState", "country", "site", "DatetimeFormats", "EncounterTransaction", "SessionInfo", "Concepts", "VisitTypes",
+        "visitUuid", "visitTypeUuid", "encounterTypeUuid", "suppressActions", "patientUuid", "encounterUuid", "locale", "currentSection", "goToNext", "initialRouterState", "country", "site", "DatetimeFormats", "EncounterTransaction", "SessionInfo", "Concepts", "OrderTypes", "VisitTypes",
         function($scope, $rootScope, $translate, $http, Visit, $state, $timeout, $filter,
                  ngDialog, Encounter, EncounterTypeConfig, AppFrameworkService, visitUuid, visitTypeUuid, encounterTypeUuid, suppressActions, patientUuid, encounterUuid,
-                 locale, currentSection,goToNext, initialRouterState, country, site, DatetimeFormats, EncounterTransaction, SessionInfo, Concepts, VisitTypes) {
+                 locale, currentSection,goToNext, initialRouterState, country, site, DatetimeFormats, EncounterTransaction, SessionInfo, Concepts, OrderTypes, VisitTypes) {
 
           const visitRef = "custom:(uuid,startDatetime,stopDatetime,location:ref,encounters:(uuid,display,encounterDatetime,patient:default,location:ref,form:(uuid,version),encounterType:ref,obs:default,orders:ref,voided,visit:(uuid,display,location:(uuid)),encounterProviders:(uuid,encounterRole,provider,dateCreated),creator:ref),patient:default,visitType:ref,attributes:default)"
           const encountersRef = "custom:(uuid,encounterDatetime,patient:(uuid,patientId,display),encounterType:(uuid,display),location:(uuid,name,display),encounterProviders:(uuid,display),form:(uuid,display),obs:(uuid,value,concept:(id,uuid,name:(display),datatype:(uuid)))";
@@ -530,6 +532,7 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
 
                 $rootScope.DatetimeFormats = DatetimeFormats;
                 $scope.Concepts = Concepts;
+                $scope.OrderTypes = OrderTypes;
                 $scope.VisitTypes = VisitTypes;
 
                 $scope.session = SessionInfo.get();


### PR DESCRIPTION
This is for displaying medication orders concept names in the encounter header:
![Screenshot 2023-09-21 at 10 25 08 AM](https://github.com/PIH/openmrs-module-pihcore/assets/1633285/c91f26d9-b993-47e1-86e3-2ca8f3abc527)
