### PR TITLE
UHM-7478, in Sierra Leone display template should include country

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/apploader/apps/patientregistration/SectionsDefault.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/apploader/apps/patientregistration/SectionsDefault.java
@@ -472,7 +472,8 @@ public class SectionsDefault {
         // TODO: Is this what we want?  Should we show a dash for all empty, non-required fields?
         StringBuilder displayTemplate = new StringBuilder();
         displayTemplate.append("{{nvl field.[" + levels.size() + "] '-'}}");
-        for (int i = levels.size() - 1; i >= 2; i--) {
+        int firstLevel = config.getRegistrationConfig().isShowCountryInAddressHiercharchy() ? 1 : 2;
+        for (int i = levels.size() - 1; i >= firstLevel; i--) {
             displayTemplate.append(", {{field.[" + i + "]}}");
         }
 

--- a/api/src/main/java/org/openmrs/module/pihcore/apploader/apps/patientregistration/SectionsSierraLeone.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/apploader/apps/patientregistration/SectionsSierraLeone.java
@@ -115,23 +115,6 @@ public class SectionsSierraLeone extends SectionsDefault {
 
         return q;
     }
-    /**
-     * In the base class this method excludes the Country field.
-     * In Sierra Leone we want to display the Country because we are capturing addresses from two other countries, Liberia and Guinea
-     * @param levels
-     * @return a String representing the full address
-     */
-    @Override
-    protected String getAddressHierarchyDisplayTemplate(List<AddressHierarchyLevel> levels) {
-        StringBuilder displayTemplate = new StringBuilder();
-        displayTemplate.append("{{nvl field.[" + levels.size() + "] '-'}}");
-        for (int i = levels.size() - 1; i >= 1; i--) {
-            displayTemplate.append(", {{field.[" + i + "]}}");
-        }
-
-        return displayTemplate.toString();
-    }
-
     private Question getLocalAddressQuestion() {
         Question q = new Question();
         q.setId("localAddressLabel");

--- a/api/src/main/java/org/openmrs/module/pihcore/apploader/apps/patientregistration/SectionsSierraLeone.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/apploader/apps/patientregistration/SectionsSierraLeone.java
@@ -115,6 +115,39 @@ public class SectionsSierraLeone extends SectionsDefault {
 
         return q;
     }
+
+    /**
+     * By default, this would generate a display template that removes the Country. In Sierra Leone,
+     * we are capturing addresses from 3 countries, Sierra Leone, Liberia and Guinea, therefore we
+     * need the country displayed
+     * @return Question
+     */
+    @Override
+    public Question getAddressQuestion() {
+        Question q = new Question();
+        q.setId("personAddressQuestion");
+        q.setLegend("registrationapp.patient.address");
+        q.setHeader("registrationapp.patient.address.question");
+
+        Field f = new Field();
+        f.setType("personAddress");
+
+        // If there are address hierarchy levels configured, use the address hierarchy widget, otherwise use the standard address widget
+        List<AddressHierarchyLevel> levels = Context.getService(AddressHierarchyService.class).getAddressHierarchyLevels();
+        if (levels != null && levels.size() > 0) {
+            f.setWidget(getAddressHierarchyWidget(levels, null, true));
+        }
+        else {
+            Map<String, String> m = new HashMap<String, String>();
+            m.put("providerName", "uicommons");
+            m.put("fragmentId", "field/personAddress");
+            f.setWidget(toObjectNode(m));
+        }
+
+        q.addField(f);
+        return q;
+    }
+
     private Question getLocalAddressQuestion() {
         Question q = new Question();
         q.setId("localAddressLabel");

--- a/api/src/main/java/org/openmrs/module/pihcore/apploader/apps/patientregistration/SectionsSierraLeone.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/apploader/apps/patientregistration/SectionsSierraLeone.java
@@ -115,37 +115,21 @@ public class SectionsSierraLeone extends SectionsDefault {
 
         return q;
     }
-
     /**
-     * By default, this would generate a display template that removes the Country. In Sierra Leone,
-     * we are capturing addresses from 3 countries, Sierra Leone, Liberia and Guinea, therefore we
-     * need the country displayed
-     * @return Question
+     * In the base class this method excludes the Country field.
+     * In Sierra Leone we want to display the Country because we are capturing addresses from two other countries, Liberia and Guinea
+     * @param levels
+     * @return a String representing the full address
      */
     @Override
-    public Question getAddressQuestion() {
-        Question q = new Question();
-        q.setId("personAddressQuestion");
-        q.setLegend("registrationapp.patient.address");
-        q.setHeader("registrationapp.patient.address.question");
-
-        Field f = new Field();
-        f.setType("personAddress");
-
-        // If there are address hierarchy levels configured, use the address hierarchy widget, otherwise use the standard address widget
-        List<AddressHierarchyLevel> levels = Context.getService(AddressHierarchyService.class).getAddressHierarchyLevels();
-        if (levels != null && levels.size() > 0) {
-            f.setWidget(getAddressHierarchyWidget(levels, null, true));
-        }
-        else {
-            Map<String, String> m = new HashMap<String, String>();
-            m.put("providerName", "uicommons");
-            m.put("fragmentId", "field/personAddress");
-            f.setWidget(toObjectNode(m));
+    protected String getAddressHierarchyDisplayTemplate(List<AddressHierarchyLevel> levels) {
+        StringBuilder displayTemplate = new StringBuilder();
+        displayTemplate.append("{{nvl field.[" + levels.size() + "] '-'}}");
+        for (int i = levels.size() - 1; i >= 1; i--) {
+            displayTemplate.append(", {{field.[" + i + "]}}");
         }
 
-        q.addField(f);
-        return q;
+        return displayTemplate.toString();
     }
 
     private Question getLocalAddressQuestion() {
@@ -161,7 +145,7 @@ public class SectionsSierraLeone extends SectionsDefault {
         // If there are address hierarchy levels configured, use the address hierarchy widget, otherwise use the standard address widget
         List<AddressHierarchyLevel> levels = Context.getService(AddressHierarchyService.class).getAddressHierarchyLevels();
         if (levels != null && levels.size() > 0) {
-            //q.setDisplayTemplate(getAddressHierarchyDisplayTemplate(levels));
+            q.setDisplayTemplate(getAddressHierarchyDisplayTemplate(levels));
             f.setWidget(getAddressHierarchyWidget(levels, getLocalContactAddressFieldMappings(), true));
         }
         else {

--- a/api/src/main/java/org/openmrs/module/pihcore/config/registration/RegistrationConfigDescriptor.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/config/registration/RegistrationConfigDescriptor.java
@@ -46,6 +46,15 @@ public class RegistrationConfigDescriptor {
     @JsonProperty
     private Integer maxPatientMatchResults;
 
+    @JsonProperty
+    private boolean showCountryInAddressHierarchy = false;
+
+    public boolean isShowCountryInAddressHiercharchy() {
+        return showCountryInAddressHierarchy;
+    }
+    public void setShowCountryInAddressHierarchy(boolean showCountryInAddressHierarchy) {
+        this.showCountryInAddressHierarchy = showCountryInAddressHierarchy;
+    }
     public boolean isAllowUnknownPatients() {
         return allowUnknownPatients;
     }


### PR DESCRIPTION
The default address section was excluding the country field when displaying the address. So, I had to overwrite this method in the SierraLeone class.