### PR TITLE
SL-469 Added checkin forms for mcoe and SL only

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/apploader/CustomAppLoaderConstants.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/apploader/CustomAppLoaderConstants.java
@@ -148,6 +148,8 @@ public class CustomAppLoaderConstants {
     public static final class Extensions {
 
         public static final String CHECK_IN_VISIT_ACTION = "pih.checkin.visitAction";
+        public static final String CHECK_IN_MATERNAL_VISIT_ACTION = "pih.checkinMaternal.visitAction";
+
         public static final String CHECK_IN_REGISTRATION_ACTION = "pih.checkin.registrationAction";
         public static final String VITALS_CAPTURE_VISIT_ACTION = "pih.form.vitals";
         public static final String CONSULT_NOTE_VISIT_ACTION = "pih.form.consult";
@@ -414,6 +416,7 @@ public class CustomAppLoaderConstants {
 
     public static final List<String> VISIT_ACTIONS_ORDER = Arrays.asList(
             Extensions.CHECK_IN_VISIT_ACTION,
+            Extensions.CHECK_IN_MATERNAL_VISIT_ACTION,
             Extensions.VITALS_CAPTURE_VISIT_ACTION,
             Extensions.CONSULT_NOTE_VISIT_ACTION,
             Extensions.MEXICO_CONSULT_ACTION,

--- a/api/src/main/java/org/openmrs/module/pihcore/apploader/CustomAppLoaderFactory.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/apploader/CustomAppLoaderFactory.java
@@ -591,25 +591,77 @@ public class CustomAppLoaderFactory implements AppFrameworkFactory {
                     //     "/registrationapp/registrationSummary.page?patientId={{patientId}}&breadcrumbOverrideProvider=coreapps&breadcrumbOverridePage=findpatient%2FfindPatient&breadcrumbOverrideApp=" + Apps.CHECK_IN + "&breadcrumbOverrideLabel=mirebalais.app.patientRegistration.checkin.label",
                     null, config.getFindPatientColumnConfig()),
                     sessionLocationHasTag("Check-In Location")));
+
+            /*
+            if (config.getCountry().equals(ConfigDescriptor.Country.SIERRA_LEONE) ) {
+                apps.add(addToHomePage(findPatientTemplateApp(CustomAppLoaderConstants.Apps.CHECK_IN,
+                                "mirebalais.app.patientRegistration.checkin.label",
+                                "fas fa-fw fa-paste",
+                                "App: mirebalais.checkin",
+                                "/pihcore/checkin/checkin.page?patientId={{patientId}}",
+                                //     "/registrationapp/registrationSummary.page?patientId={{patientId}}&breadcrumbOverrideProvider=coreapps&breadcrumbOverridePage=findpatient%2FfindPatient&breadcrumbOverrideApp=" + Apps.CHECK_IN + "&breadcrumbOverrideLabel=mirebalais.app.patientRegistration.checkin.label",
+                                null, config.getFindPatientColumnConfig()),
+                        sessionLocationHasTag("Check-In Maternal Location")));
+            } */
         }
 
-		// check-in form that appears on visit and clinicial dashboard after a visit has been started as a "Visit Action"
-        extensions.add(visitAction(CustomAppLoaderConstants.Extensions.CHECK_IN_VISIT_ACTION,
-                "mirebalais.task.checkin.label",
-                "fas fa-fw icon-check-in",
-                "link",
-                enterSimpleHtmlFormLink(PihCoreUtil.getFormResource("checkin.xml")),
-                "Task: mirebalais.checkinForm",
-                sessionLocationHasTag("Check-In Location")));
+        if (config.getCountry().equals(ConfigDescriptor.Country.SIERRA_LEONE) ) {
+            // Default SL check-in form that appears on visit and clinicial dashboard after a visit has been started as a "Visit Action"
+            extensions.add(visitAction(CustomAppLoaderConstants.Extensions.CHECK_IN_VISIT_ACTION,
+                    "mirebalais.task.checkin.label",
+                    "fas fa-fw icon-check-in",
+                    "link",
+                    enterSimpleHtmlFormLink(PihCoreUtil.getFormResource("checkin.xml")),
+                    "Task: mirebalais.checkinForm",
+                    sessionLocationHasTag("Check-In Location")));
 
-		// check-in form that appears on the Registration Page as a "Registration Action" and starts a visit
-        extensions.add(overallRegistrationAction(CustomAppLoaderConstants.Extensions.CHECK_IN_REGISTRATION_ACTION,
-                "mirebalais.task.checkin.label",
-                "fas fa-fw icon-check-in",
-                "link",
-                enterSimpleHtmlFormLink(PihCoreUtil.getFormResource("liveCheckin.xml")) + andCreateVisit(),
-                "Task: mirebalais.checkinForm",
-                sessionLocationHasTag("Check-In Location")));
+            // check-in form that appears on the Registration Page as a "Registration Action" and starts a visit
+            extensions.add(overallRegistrationAction(CustomAppLoaderConstants.Extensions.CHECK_IN_REGISTRATION_ACTION,
+                    "mirebalais.task.checkin.label",
+                    "fas fa-fw icon-check-in",
+                    "link",
+                    enterSimpleHtmlFormLink(PihCoreUtil.getFormResource("liveCheckin.xml")) + andCreateVisit(),
+                    "Task: mirebalais.checkinForm",
+                    sessionLocationHasTag("Check-In Location")));
+
+            // Maternal check-in form that appears on visit and clinicial dashboard after a visit has been started as a "Visit Action"
+            extensions.add(visitAction(CustomAppLoaderConstants.Extensions.CHECK_IN_MATERNAL_VISIT_ACTION,
+                    "mirebalais.maternalCheckin.label",
+                    "fas fa-fw icon-check-in",
+                    "link",
+                    enterSimpleHtmlFormLink(PihCoreUtil.getFormResource("checkinMaternal.xml")),
+                    "Task: mirebalais.checkinForm",
+                    sessionLocationHasTag("Check-In Maternal Location")));
+
+
+            // Maternal live check-in form that appears on the Registration Page as a "Registration Action" and starts a visit
+            extensions.add(overallRegistrationAction(CustomAppLoaderConstants.Extensions.CHECK_IN_REGISTRATION_ACTION,
+                    "mirebalais.maternalCheckin.label",
+                    "fas fa-fw icon-check-in",
+                    "link",
+                    enterSimpleHtmlFormLink(PihCoreUtil.getFormResource("liveCheckinMaternal.xml")) + andCreateVisit(),
+                    "Task: mirebalais.checkinForm",
+                    sessionLocationHasTag("Check-In Maternal Location")));
+        } else {
+            // check-in form that appears on visit and clinicial dashboard after a visit has been started as a "Visit Action"
+            extensions.add(visitAction(CustomAppLoaderConstants.Extensions.CHECK_IN_VISIT_ACTION,
+                    "mirebalais.task.checkin.label",
+                    "fas fa-fw icon-check-in",
+                    "link",
+                    enterSimpleHtmlFormLink(PihCoreUtil.getFormResource("checkin.xml")),
+                    "Task: mirebalais.checkinForm",
+                    sessionLocationHasTag("Check-In Location")));
+
+
+            // check-in form that appears on the Registration Page as a "Registration Action" and starts a visit
+            extensions.add(overallRegistrationAction(CustomAppLoaderConstants.Extensions.CHECK_IN_REGISTRATION_ACTION,
+                    "mirebalais.task.checkin.label",
+                    "fas fa-fw icon-check-in",
+                    "link",
+                    enterSimpleHtmlFormLink(PihCoreUtil.getFormResource("liveCheckin.xml")) + andCreateVisit(),
+                    "Task: mirebalais.checkinForm",
+                    sessionLocationHasTag("Check-In Location")));
+        }
 
         // TODO will this be needed after we stop using the old patient visits page view, or is is replaced by encounterTypeConfig?
         registerTemplateForEncounterType(PihEmrConfigConstants.ENCOUNTERTYPE_CHECK_IN_UUID,


### PR DESCRIPTION
Can you please check these updates?  It doesn't work perfectly yet.  It should do the following:

- For SL, there should be 4 checkin files: livecheckin, checkin, checkinMaternal, liveCheckinMaternal
- For Non-SL sites, there should be no changes
- For SL, the Maternal checkin forms will only appear for the MCOE Triage location (tag: Check In Maternal Location).  The regular and current checkin forms should appear for all other configured locations (tag: Check In Location).
- Unclear about the circular form from the home page app.  I have that code commented out in the CALF.

Questions:
- Can we use the same encounter type for the live/retro versions?
- Can we use the same actions for the live/retro versions (CHECK_IN_VISIT ACTION)?