### PR TITLE
UHM-7748, display only obs with values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ omod/src/main/compass
 target
 api/target
 omod/target
+
+# OS X auto-generated files #
+.DS_Store

--- a/omod/src/main/webapp/pages/visit/templates/encounters/defaultHtmlFormEncounterLong.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/encounters/defaultHtmlFormEncounterLong.gsp
@@ -11,17 +11,11 @@
 <div class="content encounter-summary-long">
 
     <span ng-repeat="section in templateModel.sections" class="aligned">
-        <span ng-repeat="field in (section.activeFields ? section.activeFields : section.fields)" class="aligned">
+        <span ng-repeat="field in section.activeFields" class="aligned">
             <p ng-show="field.value" class="aligned">
                 <label>{{ field.name }}</label>
                 <span class="obs-value">{{ field.value }}</span>
             </p>
-            <span ng-repeat="childField in field.fields" class="aligned">
-                <p ng-show="childField.value" class="aligned">
-                    <label>{{ (\$index == 0 || childField.name != field.fields[\$index-1].name) ? childField.name : '' }}</label>
-                    <span class="obs-value">{{ childField.value }}</span>
-                </p>
-            </span>
         </span>
     </span>
 

--- a/omod/src/main/webapp/pages/visit/templates/encounters/defaultHtmlFormEncounterLong.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/encounters/defaultHtmlFormEncounterLong.gsp
@@ -11,7 +11,7 @@
 <div class="content encounter-summary-long">
 
     <span ng-repeat="section in templateModel.sections" class="aligned">
-        <span ng-repeat="field in section.activeFields" class="aligned">
+        <span ng-repeat="field in (section.activeFields ? section.activeFields : section.fields)" class="aligned">
             <p ng-show="field.value" class="aligned">
                 <label>{{ field.name }}</label>
                 <span class="obs-value">{{ field.value }}</span>

--- a/omod/src/main/webapp/pages/visit/templates/encounters/defaultHtmlFormEncounterLong.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/encounters/defaultHtmlFormEncounterLong.gsp
@@ -11,11 +11,9 @@
 <div class="content encounter-summary-long">
 
     <span ng-repeat="section in templateModel.sections" class="aligned">
-        <span ng-repeat="field in section.fields" class="aligned">
+        <span ng-repeat="field in section.activeFields" class="aligned">
             <p ng-show="field.value" class="aligned">
-                <!-- this cryptic expression is to suppress label name if it is same as previous name -->
-                <!-- TODO: can we encapsulate this somewhere else -->
-                <label>{{ (\$index == 0 || field.name != section.fields[\$index-1].name) ? field.name : '' }}</label>
+                <label>{{ field.name }}</label>
                 <span class="obs-value">{{ field.value }}</span>
             </p>
             <span ng-repeat="childField in field.fields" class="aligned">

--- a/omod/src/main/webapp/resources/scripts/visit/visit.js
+++ b/omod/src/main/webapp/resources/scripts/visit/visit.js
@@ -123,6 +123,7 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
                             $http.get("/" + OPENMRS_CONTEXT_PATH + url)
                                 .then(function (response) {
                                     $scope.templateModel = response.data;
+                                    getFieldsWithValue($scope.templateModel.sections);
                                     if ($scope.templateModel.html) {
                                         // this enabled the "viewEncounerWithHtmlFormLong" view to display raw html returned by the htmlformentryui module
                                         $scope.html = $sce.trustAsHtml($scope.templateModel.html);
@@ -138,7 +139,31 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
                                     $scope.encounter = encounter;
                                 });
                         }
+                    }
 
+                    function getFieldsWithValue(sections) {
+                        if (sections) {
+                            sections.forEach((section) => {
+                                let activeFields = [];
+                                if (section.fields) {
+                                    for (let j = 0; j < section.fields.length; j++) {
+                                        const field = section.fields[j];
+                                        if (field.value) {
+                                            let foundField = activeFields.find(({ name }) => name === field.name);
+                                            if (foundField) {
+                                                foundField.value = foundField.value + ", " + field.value;
+                                            } else {
+                                                activeFields.push({
+                                                    name: field.name,
+                                                    value: field.value
+                                                });
+                                            }
+                                        }
+                                    }
+                                    section.activeFields = activeFields;
+                                }
+                            })
+                        }
                     }
 
                     $scope.goToLabResults = function () {

--- a/omod/src/main/webapp/resources/scripts/visit/visit.js
+++ b/omod/src/main/webapp/resources/scripts/visit/visit.js
@@ -148,21 +148,38 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
                                 if (section.fields) {
                                     for (let j = 0; j < section.fields.length; j++) {
                                         const field = section.fields[j];
-                                        if (field.value) {
-                                            let foundField = activeFields.find(({ name }) => name === field.name);
-                                            if (foundField) {
-                                                foundField.value = foundField.value + ", " + field.value;
-                                            } else {
-                                                activeFields.push({
-                                                    name: field.name,
-                                                    value: field.value
-                                                });
-                                            }
+                                        if (field.hasOwnProperty("fields")){
+                                            parseFields(activeFields, field.fields);
+                                        } else {
+                                            addFieldWithValue(activeFields, field);
                                         }
                                     }
                                     section.activeFields = activeFields;
                                 }
                             })
+                        }
+                    }
+
+                    function parseFields(fieldsWithValue, fields) {
+                        if ( fields ) {
+                            for (let i=0; i < fields.length; i++ ) {
+                                const field = fields[i];
+                                addFieldWithValue(fieldsWithValue, field);
+                            }
+                        }
+                        return fieldsWithValue;
+                    }
+                    function addFieldWithValue(fieldsWithValue, field) {
+                        if (field.value) {
+                            let foundField = fieldsWithValue.find(({ name }) => name === field.name);
+                            if (foundField) {
+                                foundField.value = foundField.value + ", " + field.value;
+                            } else {
+                                fieldsWithValue.push({
+                                    name: field.name,
+                                    value: field.value
+                                });
+                            }
                         }
                     }
 


### PR DESCRIPTION
@mogoodrich , in this PR I have added another field to the template section that is an array of fields with values. So, before I made this change here is how the templateModel data looked like:

{
  "name": "Maternal Check-In",
  "fields": [
    {
      "name": "Reason for visit",
      "datatype": "coded",
      "value": "Family planning services"
    },
    {
      "name": "Patient referred to hospital",
      "datatype": "coded",
      "value": "Yes"
    },
    {
      "name": "Role of referring person",
      "datatype": "coded",
      "value": "Peripheral Health Unit"
    },
    {
      "name": "Other referral (text)",
      "datatype": "text",
      "value": ""
    },
    {
      "name": "Address of contact person",
      "datatype": "text",
      "value": ""
    },
    {
      "name": "Telephone number of contact",
      "datatype": "text",
      "value": ""
    },
    {
      "name": "Reasons for referral (coded)",
      "datatype": "coded",
      "value": ""
    },
    {
      "name": "Reasons for referral (coded)",
      "datatype": "coded",
      "value": ""
    },
    {
      "name": "Reasons for referral (coded)",
      "datatype": "coded",
      "value": "Pain"
    },
    {
      "name": "Reasons for referral (coded)",
      "datatype": "coded",
      "value": ""
    },
    {
      "name": "Reasons for referral (coded)",
      "datatype": "coded",
      "value": ""
    },
    {
      "name": "Reasons for referral (coded)",
      "datatype": "coded",
      "value": "Bleeding"
    },
    {
      "name": "Reasons for referral (coded)",
      "datatype": "coded",
      "value": ""
    },
    {
      "name": "Reasons for referral (coded)",
      "datatype": "coded",
      "value": ""
    },
    {
      "name": "Reason for referral (text)",
      "datatype": "text",
      "value": ""
    },
    {
      "name": "Type of referral ordered",
      "datatype": "coded",
      "value": ""
    },
    {
      "name": "Method of transportation",
      "datatype": "coded",
      "value": "Motorcycle"
    },
    {
      "name": "Transportation comment",
      "datatype": "text",
      "value": ""
    }
  ]
}

So I parsed this array of all the encounter obs, and added a separate node activeFields, where I included only the obs with values. And if an obs had multiple answers, then I combined those answers to one string comma delimited:
[
  {
    "name": "Reason for visit",
    "value": "Postnatal visit"
  },
  {
    "name": "Patient referred to hospital",
    "value": "Yes"
  },
  {
    "name": "Role of referring person",
    "value": "Traditional birth attendant (TBA)"
  },
  {
    "name": "Reasons for referral (coded)",
    "value": "Stage of labor, Antenatal visit, Other"
  },
  {
    "name": "Reason for referral (text)",
    "value": "doare"
  },
  {
    "name": "Type of referral ordered",
    "value": "Triage service"
  },
  {
    "name": "Method of transportation",
    "value": "Walking"
  }
]

Here is how the encounter was displaying before I made this change:

![Screenshot 2024-02-21 at 10 00 02 AM](https://github.com/PIH/openmrs-module-pihcore/assets/1633285/b9bbaece-1f55-49a8-9d72-dd1d77f43fcd)

And here is how it looks now after adding the activeFields array of obs with values:
![Screenshot 2024-02-21 at 10 23 01 AM](https://github.com/PIH/openmrs-module-pihcore/assets/1633285/11af7f5f-103c-4661-a3ed-bdf90a118ba1)
