### PR TITLE
UHM-7716: prevent adding queue entries for past visits

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/htmlformentry/action/AddPatientToQueueAction.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/htmlformentry/action/AddPatientToQueueAction.java
@@ -54,31 +54,13 @@ public class AddPatientToQueueAction implements CustomFormSubmissionAction {
                     criteria.setServices(Arrays.asList(serviceQueue));
                     QueueServicesWrapper queueServicesWrapper = Context.getRegisteredComponents(QueueServicesWrapper.class).get(0);
                     List<Queue> queues = queueServicesWrapper.getQueueService().getQueues(criteria);
-                    Queue queue = null;
-                    QueueEntry queueEntry = null;
                     if (queues.isEmpty()) {
                         throw new RuntimeException("AddPatientToQueueAction not executing as no queue with service concept " + serviceQueue.getName() + " could be found ");
                     }
                     if (queues.size() > 1) {
                         throw new RuntimeException("AddPatientToQueueAction not executing as there are more than one queue with service concept " + serviceQueue.getName());
                     }
-                    queue = queues.get(0);
-
-                    queueEntry = new QueueEntry();
-                    queueEntry.setQueue(queue);
-                    queueEntry.setPatient(patient);
-
-                    List<Concept> allowedStatuses = queueServicesWrapper.getAllowedStatuses(queue);
-                    if (!allowedStatuses.isEmpty()) {
-                        queueEntry.setStatus(allowedStatuses.get(0));
-                    }
-
-                    List<Concept> allowedPriorities = queueServicesWrapper.getAllowedPriorities(queue);
-                    if (!allowedPriorities.isEmpty()) {
-                        queueEntry.setPriority(allowedPriorities.get(0));
-                    }
-                    queueEntry.setStartedAt(encounter.getEncounterDatetime());
-                    queueEntry.setVisit(encounter.getVisit());
+                    Queue queue = queues.get(0);
 
                     QueueEntrySearchCriteria searchCriteria = new QueueEntrySearchCriteria();
                     searchCriteria.setPatient(patient);
@@ -87,18 +69,33 @@ public class AddPatientToQueueAction implements CustomFormSubmissionAction {
                     List<QueueEntry> queueEntries = queueServicesWrapper.getQueueEntryService().getQueueEntries(searchCriteria);
                     boolean isPatientAlreadyOnTheQueue = false;
                     for (QueueEntry entry : queueEntries) {
-                        if (QueueUtils.datesOverlap(entry.getStartedAt(), entry.getEndedAt(), queueEntry.getStartedAt(), queueEntry.getEndedAt())) {
+                        if (QueueUtils.datesOverlap(entry.getStartedAt(), entry.getEndedAt(), encounter.getEncounterDatetime(), null)) {
                             isPatientAlreadyOnTheQueue = true;
                             break;
                         }
                     }
                     if (!isPatientAlreadyOnTheQueue) {
                         try {
+                            QueueEntry queueEntry = new QueueEntry();
+                            queueEntry.setQueue(queue);
+                            queueEntry.setPatient(patient);
+                            List<Concept> allowedStatuses = queueServicesWrapper.getAllowedStatuses(queue);
+                            if (!allowedStatuses.isEmpty()) {
+                                queueEntry.setStatus(allowedStatuses.get(0));
+                            }
+                            List<Concept> allowedPriorities = queueServicesWrapper.getAllowedPriorities(queue);
+                            if (!allowedPriorities.isEmpty()) {
+                                queueEntry.setPriority(allowedPriorities.get(0));
+                            }
+                            queueEntry.setStartedAt(encounter.getEncounterDatetime());
+                            queueEntry.setVisit(encounter.getVisit());
                             queueServicesWrapper.getQueueEntryService().saveQueueEntry(queueEntry);
                         } catch (Exception e) {
                             throw new RuntimeException("AddPatientToQueueAction failed to add patient to queue", e);
                         }
                     }
+                    // no need to continue iterating through the encounter obs, it's only one obs that triggers the post-submit action
+                    break;
                 }
             }
         }

--- a/api/src/main/java/org/openmrs/module/pihcore/htmlformentry/action/AddPatientToQueueAction.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/htmlformentry/action/AddPatientToQueueAction.java
@@ -8,6 +8,7 @@ import org.openmrs.Concept;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Patient;
+import org.openmrs.Visit;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.htmlformentry.CustomFormSubmissionAction;
 import org.openmrs.module.htmlformentry.FormEntrySession;
@@ -44,6 +45,13 @@ public class AddPatientToQueueAction implements CustomFormSubmissionAction {
         }
         Patient patient = formEntrySession.getPatient();
         Encounter encounter = formEntrySession.getEncounter();
+        Visit visit = encounter.getVisit();
+        if ( visit != null && visit.getStopDatetime() != null) {
+            // this post submit action do not apply to retrospective entries, only for active point of care visits
+            log.warn("AddPatientToQueueAction not executing because this is not an active visit");
+            // we should not throw an error, because the user should be able to edit other obs on this check-in encounter
+            return;
+        }
 
         for (Obs candidate : encounter.getObsAtTopLevel(false)) {
             if (candidate.getConcept().equals(addToQueueConcept)) {

--- a/api/src/test/java/org/openmrs/module/pihcore/action/AddPatientToQueueActionTest.java
+++ b/api/src/test/java/org/openmrs/module/pihcore/action/AddPatientToQueueActionTest.java
@@ -79,6 +79,7 @@ public class AddPatientToQueueActionTest {
         addPatientToQueueAction = new AddPatientToQueueAction();
         when(mockFormEntrySession.getSubmissionActions()).thenReturn(mockFormSubmissionActions);
         when(mockFormEntrySession.getContext()).thenReturn(mockFormEntryContext);
+        when(mockFormEntryContext.getMode()).thenReturn(FormEntryContext.Mode.ENTER);
         conceptService = mock(ConceptService.class);
         addToQueueConcept = new Concept();
         mcoeTriageService = new Concept();
@@ -151,6 +152,7 @@ public class AddPatientToQueueActionTest {
         encounter.addObs(referToMCOE);
         Visit visit = new Visit();
         visit.addEncounter(encounter);
+        visit.setPatient(patient);
         Queue queue = new Queue();
         queue.setService(mcoeTriageService);
         QueueSearchCriteria searchCriteria = new QueueSearchCriteria();
@@ -170,6 +172,7 @@ public class AddPatientToQueueActionTest {
         QueueEntrySearchCriteria qeCriteria = new QueueEntrySearchCriteria();
         qeCriteria.setPatient(patient);
         qeCriteria.setQueues(Collections.singletonList(queue));
+        qeCriteria.setIsEnded(null);
         when(mockQueueEntryDao.getQueueEntries(qeCriteria)).thenReturn(Arrays.asList(queueEntry));
 
         addPatientToQueueAction.applyAction(mockFormEntrySession);


### PR DESCRIPTION
@mogoodrich , while testing this MCOE check-in form, I have noticed a strange error. If I go back to a past visit which had MCOE check-in encounter with Refer to MCOE Triage check-in obs, and try to edit the encounter then the postsubmit action is executed again and another queue entry is created on the past visit:

![Screenshot 2024-02-23 at 9 43 03 AM](https://github.com/PIH/openmrs-module-pihcore/assets/1633285/a3d40c33-73c7-4e2f-bf19-e36a1af6aa42)

When I click to edit the MCOE Check-in encounter, the Refer to MCOE triage question is not displayed, because of this code:
https://github.com/PIH/openmrs-config-pihsl/blob/master/configuration/pih/htmlforms/checkinMaternal.xml#L259

            <ifMode mode="ENTER" include="true">
                <includeIf velocityTest="($visit.open)">
                    <!-- if this is an active visit (visit.open), and we are entering this form for the first time (mode=ENTER) -->
                    <fieldset class="queue">
                        <legend>
                            <uimessage code="MCOE Triage"/>
                        </legend>
                        <h3>
                            <uimessage code="MCOE Triage"/>
                        </h3>


                        <p class="left">
                            <obs conceptId="CIEL:1272" style="checkbox" id="referToMCOETriage"
                                 answerConceptId="PIH:14976" answerCode="Refer to MCOE triage" />
                        </p>
                    </fieldset>
                </includeIf>
            </ifMode>

But the postSubmissionAction is executed, and because other problems in the queue module it would create duplicate queue entries. 

I even try something like this in the check-in form, but it did not work:

```
<ifMode mode="ENTER" include="true">
        <includeIf velocityTest="($visit.open)">
            <postSubmissionAction class="org.openmrs.module.pihcore.htmlformentry.action.AddPatientToQueueAction"/>
        </includeIf>
</ifMode>
```

The post submit action was included and executed on the edit mode, even if modified the form. I guess it retrieves the version of the form that was used to create the encounter initially? So, maybe for any new encounter the little code above would work?

Anyway, for now I thought I would modify the AddPatientToQueueAction postsubmitaction to not execute if the encounter is part of a visit that was closed. Does this make sense? Thanks!
