### PR TITLE
SL-511 Change concept mapping for date of death for reporting

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/reporting/dataset/manager/ConsultationsDataSetManager.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/reporting/dataset/manager/ConsultationsDataSetManager.java
@@ -42,7 +42,7 @@ public class ConsultationsDataSetManager extends BaseEncounterDataSetManager {
 
         // note: does not include diagnoses--use diagnoses export for thoses
         addObsColumn(dsd, "dispo", "PIH:8620", converters.getObsValueCodedNameConverter());
-        addObsColumn(dsd, "death_date", "PIH:DATE OF DEATH", converters.getObsValueDatetimeConverter());
+        addObsColumn(dsd, "death_date", "org.openmrs.module.emrapi:Date of Death", converters.getObsValueDatetimeConverter());
         addObsColumn(dsd, "return_visit_date", "PIH:RETURN VISIT DATE", converters.getObsValueDatetimeConverter());
         addObsColumn(dsd, "clinical_notes", "PIH:CLINICAL IMPRESSION COMMENTS", converters.getObsValueTextConverter());
 


### PR DESCRIPTION
Use the generic mapping for Date of Death.  This will be useful when we move to datetime.  I believe the same code will work for datetime (as it does now for date).