### PR TITLE
SL-553: add ability to set queue entry priority

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/apploader/CustomAppLoaderFactory.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/apploader/CustomAppLoaderFactory.java
@@ -590,7 +590,7 @@ public class CustomAppLoaderFactory implements AppFrameworkFactory {
                     "mirebalais.task.triage.label",
                     "fas fa-fw fa-ambulance",
                     "link",
-                    enterSimpleHtmlFormLink(PihCoreUtil.getFormResource("triage.xml")),
+                    enterStandardHtmlFormLink(PihCoreUtil.getFormResource("triage.xml")),
                     "Task: emr.triage",
                     and(sessionLocationHasTag("MCH Triage Location"),
                             visitDoesNotHaveEncounterOfType(SierraLeoneConfigConstants.ENCOUNTERTYPE_SIERRALEONEMCHTRIAGE_UUID))));


### PR DESCRIPTION
I just added to the existing AddPatientToQueueAction the ability to set the queue entry priority via another hidden coded question that could be set automatically based on the triage symptoms. 