### PR TITLE
SL-741: enhance the ObsByEncounter widget to display numeric obs with abnormal values

### DIFF
--- a/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/ObsByEncounterFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/ObsByEncounterFragmentController.java
@@ -23,10 +23,12 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -126,8 +128,20 @@ public class ObsByEncounterFragmentController {
             existingList.add(obs);
             encounterObs.put(obs.getEncounter(), existingList);
         }
+        List<Encounter> encounters = new ArrayList<>(encounterObs.keySet());
+        // order the encounters by encounterDatetime descending
+        Collections.sort(encounters, (e1, e2) -> e2.getEncounterDatetime().compareTo(e1.getEncounterDatetime()));
+        Map<Encounter, List<Obs>> sortedEncObs = new LinkedHashMap<>();
+        for (Encounter encounter : encounters) {
+            sortedEncObs.put(encounter, encounterObs.get(encounter));
+        }
+
+        Boolean showTime = app.getConfig().get("showTime") != null ? app.getConfig().get("showTime").getBooleanValue() : false;
+        model.put("minValue", app.getConfig().get("minValue") != null ? app.getConfig().get("minValue").getTextValue() : "");
+        model.put("maxValue", app.getConfig().get("maxValue") != null ? app.getConfig().get("maxValue").getTextValue() : "");
+        model.put("showTime", showTime);
         model.put("visitUrl", visitUrl);
-        model.put("encounterObs", encounterObs);
+        model.put("encounterObs", sortedEncObs);
     }
 
     private String getConfigValue(AppDescriptor app, String configValue) {

--- a/omod/src/main/webapp/fragments/dashboardwidgets/obsByEncounter.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/obsByEncounter.gsp
@@ -42,15 +42,28 @@
                     <td>
                         <span class="encounter-date">
                             <a class="visit-link" href="${ ui.urlBind("/" + contextPath + visitUrl, [ "patient.uuid": patient.id, "visit.uuid": enc.visit.uuid ]) }">
-                                ${ui.formatDatePretty(enc.encounterDatetime)}
+                                <% if (showTime) { %>
+                                    ${ui.formatDatetimePretty(enc.encounterDatetime)}
+                                <% } else { %>
+                                    ${ui.formatDatePretty(enc.encounterDatetime)}
+                                <% } %>
                             </a>
                         </span>
                     </td>
                     <td>
                         <span>
                             <% obsList.eachWithIndex { obs, index -> %>
-                                ${ui.format(obs)}${obsList.size() - 1 > index ? ", " : ""}
-                            <%  }%>
+                                <% if (obs.valueNumeric) { %>
+                                    <%  if ((minValue && obs.valueNumeric && (new BigDecimal(obs.valueNumeric) < new BigDecimal(minValue)))
+                                            || (maxValue && obs.valueNumeric && (new BigDecimal(obs.valueNumeric) > new BigDecimal(maxValue)))) {  %>
+                                        <span style="color: red">${ui.format(obs.valueNumeric)}</span>
+                                    <% } else { %>
+                                        ${ui.format(obs.valueNumeric)}
+                                    <% }  %>
+                                <% } else { %>
+                                    ${ui.format(obs)}${obsList.size() - 1 > index ? ", " : ""}
+                                <% } %>
+                            <% } %>
                         </span>
                     </td>
                 </tr>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/obsByEncounter.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/obsByEncounter.gsp
@@ -54,11 +54,11 @@
                         <span>
                             <% obsList.eachWithIndex { obs, index -> %>
                                 <% if (obs.valueNumeric) { %>
-                                    <%  if ((minValue && obs.valueNumeric && (new BigDecimal(obs.valueNumeric) < new BigDecimal(minValue)))
-                                            || (maxValue && obs.valueNumeric && (new BigDecimal(obs.valueNumeric) > new BigDecimal(maxValue)))) {  %>
+                                    <%  if ((minValue && (new BigDecimal(obs.valueNumeric) < new BigDecimal(minValue)))
+                                            || (maxValue && (new BigDecimal(obs.valueNumeric) > new BigDecimal(maxValue)))) {  %>
                                         <span style="color: red">${ui.format(obs.valueNumeric)}</span>
                                     <% } else { %>
-                                        ${ui.format(obs.valueNumeric)}
+                                        ${ui.format(obs.valueNumeric)}${obsList.size() - 1 > index ? ", " : ""}
                                     <% }  %>
                                 <% } else { %>
                                     ${ui.format(obs)}${obsList.size() - 1 > index ? ", " : ""}


### PR DESCRIPTION
I was able to enhance the existing ObsByEncounter widget to display the temperatures as it is spec out in SL-741:

![Screenshot 2024-10-04 at 10 41 27 AM](https://github.com/user-attachments/assets/1403e14e-2344-4b69-a943-7d9b9f993a0a)


here is the dashboard config:

![Screenshot 2024-10-04 at 10 48 13 AM](https://github.com/user-attachments/assets/84f3480d-5a7b-407a-ac4b-57cceac6631a)
