### PR TITLE
UHM-8220: display non-coded dx in the view mode

### DIFF
--- a/omod/src/main/webapp/pages/visit/templates/encounters/clinicConsultLong.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/encounters/clinicConsultLong.gsp
@@ -45,7 +45,16 @@
             </p>
         </div>
     </div>
-
+    <div class="clear">
+        <div class="left-column">
+            <h3 class="consult-header">${ ui.message('mirebalaisreports.noncodeddiagnoses.name') }</h3>
+        </div>
+        <div class="right-column">
+            <p>
+                {{ encounter.obs | byConcept:Concepts.nonCodedDiagnosis:true | obs:'value' }}
+            </p>
+        </div>
+    </div>
     <div>
         <div class="left-column">
             <h3 class="consult-header">${ ui.message('coreapps.consult.disposition') }</h3>

--- a/omod/src/main/webapp/pages/visit/templates/sections/dxLong.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/sections/dxLong.gsp
@@ -46,6 +46,17 @@
         </div>
     </div>
 
+    <div>
+        <div class="left-column">
+            <h3 class="dx-header">${ ui.message('mirebalaisreports.noncodeddiagnoses.name') }</h3>
+        </div>
+        <div class="right-column">
+            <p>
+                {{ encounter.obs | byConcept:Concepts.nonCodedDiagnosis:true | obs:'value' }}
+            </p>
+        </div>
+    </div>
+
     <div class="comments-div">
         <div class="left-column">
             <h3 class="dx-header">${ ui.message('coreapps.consult.freeTextComments') }</h3>

--- a/omod/src/main/webapp/pages/visit/templates/sections/dxSectionHeading.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/sections/dxSectionHeading.gsp
@@ -12,6 +12,9 @@
     <span ng-repeat="diag in encounter.obs | byConcept:Concepts.diagnosisConstruct | withoutCodedMember:Concepts.diagnosisOrder:Concepts.primaryOrder">
         {{ diag | diagnosisShort }}{{ \$last ? "" : "," }}
     </span>
+    <span>
+        {{ ((encounter.obs | byConcept:Concepts.diagnosisConstruct | withCodedMember:Concepts.diagnosisOrder:Concepts.primaryOrder).length == 0 ) && (encounter.obs | byConcept:Concepts.diagnosisConstruct | withoutCodedMember:Concepts.diagnosisOrder:Concepts.primaryOrder).length == 0 ? "" : ", " }}{{ encounter.obs | byConcept:Concepts.nonCodedDiagnosis:true | obs:'value' }}
+    </span>
 </span>
 
 <span ng-show="showEncounterDetails" ng-include="'templates/showEncounterDetails.page'" />


### PR DESCRIPTION
I think these are the only templates that needed to be modified to display the non-coded dx. Please let me know if I miss any. Maybe the best way to test this update is to deploy it to humci to see if there are other encounter templates that needed to be modified.