### PR TITLE
(chore) UHM-8241 - add html classes to various widgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ omod/target
 
 # OS X auto-generated files #
 .DS_Store
+
+.vscode/
+.swp

--- a/omod/src/main/webapp/fragments/dashboardwidgets/appointments.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/appointments.gsp
@@ -1,4 +1,4 @@
-<div class="info-section appointments">
+<div class="info-section appointments ${app.id}">
     <div class="info-header">
         <i class="${app.icon}"></i>
         <h3>${ ui.message(app.label).toUpperCase() }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/appointments.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/appointments.gsp
@@ -1,4 +1,4 @@
-<div class="info-section">
+<div class="info-section appointments">
     <div class="info-header">
         <i class="${app.icon}"></i>
         <h3>${ ui.message(app.label).toUpperCase() }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/discreteValues.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/discreteValues.gsp
@@ -1,5 +1,5 @@
 
-<div class="info-section">
+<div class="info-section ${app.id}">
     <div class="info-header">
         <i class="${app.icon}"></i>
         <h3>${ ui.message(app.label) }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/encounters.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/encounters.gsp
@@ -1,5 +1,5 @@
 
-<div class="info-section encounters-by-type-widget">
+<div class="info-section encounters-by-type-widget ${app.id}">
     <div class="info-header">
         <i class="${app.icon}"></i>
         <h3>${ ui.message(app.label) }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/labResults.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/labResults.gsp
@@ -1,4 +1,4 @@
-<div class="info-section lab-results-widget">
+<div class="info-section lab-results-widget ${app.id}">
     <div class="info-header">
         <i class="${app.icon}"></i>
         <h3>${ ui.message(app.label) }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/medsDispensed.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/medsDispensed.gsp
@@ -1,4 +1,4 @@
-<div class="info-section meds-dispensed-widget">
+<div class="info-section meds-dispensed-widget ${app.id}">
     <div class="info-header">
         <i class="fas fa-fw fa-pills"></i>
         <h3>${ ui.message("mirebalais.dispensing.title") }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/newbornIndicators.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/newbornIndicators.gsp
@@ -3,7 +3,7 @@
         color: red;
     }
 </style>
-<div class="info-section">
+<div class="info-section newborn-indicator">
     <div class="info-header">
         <i class="${app.icon}"></i>
         <h3>${ ui.message(app.label) }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/newbornIndicators.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/newbornIndicators.gsp
@@ -3,7 +3,7 @@
         color: red;
     }
 </style>
-<div class="info-section newborn-indicator">
+<div class="info-section newborn-indicator ${app.id}">
     <div class="info-header">
         <i class="${app.icon}"></i>
         <h3>${ ui.message(app.label) }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/obsByEncounter.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/obsByEncounter.gsp
@@ -18,7 +18,7 @@
 
 </style>
 
-<div class="info-section encounters-by-type-widget">
+<div class="info-section encounters-by-type-widget ${app.id}">
     <div class="info-header">
         <i class="${app.icon}"></i>
         <h3>${ ui.message(app.label) }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/patientLocation.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/patientLocation.gsp
@@ -1,5 +1,5 @@
 <% if (patientStatus.length() > 0 ) { %>
-    <div class="info-section patient-location">
+    <div class="info-section patient-location ${app.id}">
         <div class="info-header">
             <i class="icon-map-marker"></i>
             <h3>${ ui.message("pihcore.patient.location") }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/patientLocation.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/patientLocation.gsp
@@ -1,5 +1,5 @@
 <% if (patientStatus.length() > 0 ) { %>
-    <div class="info-section">
+    <div class="info-section patient-location">
         <div class="info-header">
             <i class="icon-map-marker"></i>
             <h3>${ ui.message("pihcore.patient.location") }</h3>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/statusData.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/statusData.gsp
@@ -1,5 +1,5 @@
 
-<div class="info-section status-data-widget">
+<div class="info-section status-data-widget ${app.id}">
     <div class="info-header">
         <i class="${app.icon}"></i>
         <h3>${ ui.message(app.label) }</h3>


### PR DESCRIPTION
Add html class names to various widgets. This makes is easier to select and hide them when embedding the O2 pregnancy dashboard into an O3 workspace.

![image](https://github.com/user-attachments/assets/86b5af76-0f92-49ca-bbd5-5de5bfaf149c)

For widgets that are configurable to show different data (like the encounters widget), I added `${app.id}` (ex: "pregnancy.dashboard.ancInitialEncounters") as a class name. For widgets that are not configurable to show different data (like the appointments widget) I just hard-coded a string.

I'll make a corresponding PR for widgets in `opnmrs-module-coreapps` as well.
