### PR TITLE
UHM-8292 - Remove old Jackson version

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -81,20 +81,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-core-asl</artifactId>
-			<version>1.9.13</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.9.13</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>${project.parent.groupId}</groupId>
 			<artifactId>${project.parent.artifactId}-api</artifactId>
 			<version>${project.parent.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -726,20 +726,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-core-asl</artifactId>
-            <version>1.9.13</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.13</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombokVersion}</version>


### PR DESCRIPTION
Doing a `mvn dependency:tree` on pihcore shows that com.fasterxml.jackson.core:jackson-core:jar:2.14.1 is provided by OpenMRS core.

So this removes the (older) org.codehaus.jacson version 1.9.13 libraries that I think we had for some sort of attempt at compatibility with older versions of some openmrs modules at one point, but which doesn't seem needed any longer.

Building passes fine with these removed.