### PR TITLE
UHM-8591: prevent NPE when patient has no birthdate

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/search/PihPatientSearchAlgorithm.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/search/PihPatientSearchAlgorithm.java
@@ -168,7 +168,7 @@ public class PihPatientSearchAlgorithm  implements SimilarPatientSearchAlgorithm
                     patientEstimatedAge = 0;
                 }
 
-                if (patientEstimatedAge != null) {
+                if (patientEstimatedAge != null && match.getAge() != null) {
                     int yearsBetween = Math.abs(patientEstimatedAge - match.getAge());
                     if (yearsBetween < 5) {
                         score += (6 - yearsBetween);

--- a/api/src/test/java/org/openmrs/module/pihcore/search/PihPatientSearchAlgorithmTest.java
+++ b/api/src/test/java/org/openmrs/module/pihcore/search/PihPatientSearchAlgorithmTest.java
@@ -13,13 +13,17 @@ import org.openmrs.module.pihcore.PihCoreContextSensitiveTest;
 import org.openmrs.module.pihcore.metadata.Metadata;
 import org.openmrs.module.registrationcore.api.search.PatientAndMatchQuality;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.testcontainers.shaded.org.apache.commons.lang3.ObjectUtils;
 
 import java.util.Date;
 import java.util.List;
 import java.util.Properties;
+import java.util.Map;
+import java.util.HashMap;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
@@ -56,6 +60,29 @@ public class PihPatientSearchAlgorithmTest extends PihCoreContextSensitiveTest {
     }
 
     @Test
+    public void shouldFindNameMatchWithoutBirthdate() {
+
+        Patient patient = new Patient();
+
+        PersonName name = new PersonName();
+        patient.addName(name);
+        name.setGivenName("Ion");
+        name.setFamilyName("Popa");
+
+        patient.setBirthdate(new Date());
+        patient.setGender("M");
+        Map<String, Object> otherDataPoints = new HashMap<>();
+        otherDataPoints.put("birthdateYears", new Integer(52));
+
+        List<PatientAndMatchQuality> results = searchAlgorithm.findSimilarPatients(patient, otherDataPoints, null, 10);
+
+        //one of the two patient matches has no birthdate
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getPatient().getPersonName().getGivenName(), is("Ion"));
+        assertThat(results.get(0).getPatient().getPersonName().getFamilyName(), is("Popa"));
+        assertThat(results.get(0).getPatient().getBirthdate(), nullValue());
+    }
+    @Test
     public void shouldFindNamePhoneticsMatch() {
 
         Patient patient = new Patient();
@@ -67,8 +94,10 @@ public class PihPatientSearchAlgorithmTest extends PihCoreContextSensitiveTest {
 
         patient.setBirthdate(new Date());
         patient.setGender("M");
+        Map<String, Object> otherDataPoints = new HashMap<>();
+        otherDataPoints.put("birthdateYears", new Integer(52));
 
-        List<PatientAndMatchQuality> results = searchAlgorithm.findSimilarPatients(patient, null, null, 10);
+        List<PatientAndMatchQuality> results = searchAlgorithm.findSimilarPatients(patient, otherDataPoints, null, 10);
 
         assertThat(results.size(), is(1));
         assertThat(results.get(0).getPatient().getPersonName().getGivenName(), is("Jarus"));

--- a/api/src/test/java/org/openmrs/module/pihcore/search/PihPatientSearchAlgorithmTest.java
+++ b/api/src/test/java/org/openmrs/module/pihcore/search/PihPatientSearchAlgorithmTest.java
@@ -94,10 +94,8 @@ public class PihPatientSearchAlgorithmTest extends PihCoreContextSensitiveTest {
 
         patient.setBirthdate(new Date());
         patient.setGender("M");
-        Map<String, Object> otherDataPoints = new HashMap<>();
-        otherDataPoints.put("birthdateYears", new Integer(52));
 
-        List<PatientAndMatchQuality> results = searchAlgorithm.findSimilarPatients(patient, otherDataPoints, null, 10);
+        List<PatientAndMatchQuality> results = searchAlgorithm.findSimilarPatients(patient, null, null, 10);
 
         assertThat(results.size(), is(1));
         assertThat(results.get(0).getPatient().getPersonName().getGivenName(), is("Jarus"));

--- a/api/src/test/java/org/openmrs/module/pihcore/search/PihPatientSearchAlgorithmTest.java
+++ b/api/src/test/java/org/openmrs/module/pihcore/search/PihPatientSearchAlgorithmTest.java
@@ -13,7 +13,6 @@ import org.openmrs.module.pihcore.PihCoreContextSensitiveTest;
 import org.openmrs.module.pihcore.metadata.Metadata;
 import org.openmrs.module.registrationcore.api.search.PatientAndMatchQuality;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.testcontainers.shaded.org.apache.commons.lang3.ObjectUtils;
 
 import java.util.Date;
 import java.util.List;

--- a/api/src/test/resources/searchTestDataset.xml
+++ b/api/src/test/resources/searchTestDataset.xml
@@ -45,6 +45,7 @@
     <person person_id="92" gender="M" birthdate="1984-03-25" birthdate_estimated="false" dead="false" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="dd5576a6-1691-11df-97a5-7038c432aabf"/>
     <person person_id="95" gender="M" birthdate="2003-05-06" birthdate_estimated="true" dead="false" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="dd5577c4-1691-11df-97a5-7038c432aabf"/>
     <person person_id="98" gender="M" birthdate="1960-06-13" birthdate_estimated="true" dead="false" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="dd5578da-1691-11df-97a5-7038c432aabf"/>
+    <person person_id="99" gender="M" birthdate_estimated="true" dead="false" creator="1" date_created="2009-01-18 00:00:00.0" voided="false" uuid="09C75220-1C82-44DA-AFE3-E56575A05740"/>
 
     <patient patient_id="2"  creator="1" date_created="2005-09-22 00:00:00.0" voided="false"/>
     <patient patient_id="6"  creator="1" date_created="2006-01-18 00:00:00.0" voided="false"/>
@@ -87,6 +88,7 @@
     <patient patient_id="92"  creator="1" date_created="2006-01-18 00:00:00.0" voided="false"/>
     <patient patient_id="95"  creator="1" date_created="2006-01-18 00:00:00.0" voided="false"/>
     <patient patient_id="98"  creator="1" date_created="2006-01-18 00:00:00.0" voided="false"/>
+    <patient patient_id="99"  creator="1" date_created="2009-01-18 00:00:00.0" voided="false"/>
 
     <person_name person_name_id="2" preferred="true" person_id="2" prefix="Mr." given_name="Horatio" middle_name="L" family_name="Hornblower" family_name_suffix="Esq." creator="1" date_created="2005-09-22 00:00:00.0" voided="false" uuid="de8140e0-1691-11df-97a5-7038c432aabf"/>
     <person_name person_name_id="13" preferred="false" person_id="13" given_name="Jarus" middle_name="Agemba" family_name="Rapondi" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="de814b7c-1691-11df-97a5-7038c432aabf"/>
@@ -134,6 +136,7 @@
     <person_name person_name_id="102" preferred="false" person_id="98" given_name="Kiptogom" middle_name="Kuria" family_name="Nari" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="781dcbf8-b83f-481e-9dbb-037605448c84"/>
     <person_name person_name_id="103" preferred="false" person_id="98" given_name="Kiptogom" middle_name="Kuria" family_name="Nari" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="73d48d9e-78fa-45f6-9b48-5240932c74bc"/>
     <person_name person_name_id="9347" preferred="true" person_id="1" given_name="Super" middle_name="" family_name="User" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="ded2585e-1691-11df-97a5-7038c432aabf"/>
+    <person_name person_name_id="9348" preferred="false" person_id="99" given_name="Ion" middle_name="Dan" family_name="Popa" creator="1" date_created="2009-01-18 00:00:00.0" voided="false" uuid="85C82F28-4DE0-4148-ADE0-6C43C191F8BC"/>
 
     <person_address person_address_id="2" person_id="2" preferred="false" address1="1050 Wishard Blvd." address2="RG5" city_village="Indianapolis" state_province="IN" postal_code="46202" country="USA" creator="1" date_created="2005-09-22 00:00:00.0" voided="false" uuid="ddc794bd-1691-11df-97a5-7038c432aabf"/>
     <person_address person_address_id="13" person_id="13" preferred="false" city_village="Shiseso" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="ddc9d92e-1691-11df-97a5-7038c432aabf"/>
@@ -175,6 +178,7 @@
     <person_address person_address_id="92" person_id="92" preferred="false" city_village="Ziwa Machine" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="ddca27ba-1691-11df-97a5-7038c432aabf"/>
     <person_address person_address_id="95" person_id="95" preferred="false" city_village="Kapkarong" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="ddca290b-1691-11df-97a5-7038c432aabf"/>
     <person_address person_address_id="98" person_id="98" preferred="false" city_village="Esangalo" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="ddca2a59-1691-11df-97a5-7038c432aabf"/>
+    <person_address person_address_id="99" person_id="99" preferred="false" city_village="Shiseso" creator="1" date_created="2009-01-18 00:00:00.0" voided="false" uuid="DB32D408-DE12-40EB-8EE1-FD7962C276C6"/>
 
     <person_attribute_type person_attribute_type_id="10" name="Telephone Number" description="Telephone number of patient" format="java.lang.String" searchable="false" creator="1" date_created="2007-05-04 09:59:23.0" retired="false" uuid="14d4f066-15f5-102d-96e4-000c29c2a5d7" sort_weight="1"/>
     <person_attribute_type person_attribute_type_id="11" name="First Name of Mother" description="Mother's First Name" format="java.lang.String" searchable="false" creator="1" date_created="2007-05-04 09:59:23.0" retired="false" uuid="8d871d18-c2cc-11de-8d13-0010c6dffd0f" sort_weight="1"/>
@@ -190,5 +194,7 @@
 
     <name_phonetics name_phonetics_id="1" rendered_string="J620" person_name_id="13" field="1" renderer_class_name="org.apache.commons.codec.language.Soundex"/>
     <name_phonetics name_phonetics_id="2" rendered_string="R153" person_name_id="13" field="3" renderer_class_name="org.apache.commons.codec.language.Soundex"/>
+    <name_phonetics name_phonetics_id="3" rendered_string="I500" person_name_id="9348" field="1" renderer_class_name="org.apache.commons.codec.language.Soundex"/>
+    <name_phonetics name_phonetics_id="4" rendered_string="P100" person_name_id="9348" field="3" renderer_class_name="org.apache.commons.codec.language.Soundex"/>
 
 </dataset>


### PR DESCRIPTION
@mogoodrich , here is the fix for the NPE when potential matches have no birthdate. I created a unit test and was able to reproduce the NPE we were seeing in humci yesterday before you cleaned up the test data. Thanks for reviewing! 