### PR TITLE
SL-983: remove entries older than 12 hours from the MCOE triage queue

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/task/PihCoreScheduledTaskExecutor.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/task/PihCoreScheduledTaskExecutor.java
@@ -29,6 +29,7 @@ public class PihCoreScheduledTaskExecutor extends ScheduledExecutorFactoryBean {
                 task(fiveMinutes, oneHour, PihCloseStalePullRequestsTask.class),
                 task(fiveMinutes, oneHour, PihCloseStaleCreateRequestsTask.class),
                 task(fiveMinutes, oneHour, PihCloseStaleVisitsTask.class),
+                task(fiveMinutes, oneHour, PihRemovePatientsFromMCOEQueue.class),
                 task(fiveMinutes, twelveHours, ClosePregnancyProgramTask.class),
                 task(fiveMinutes, twelveHours, CloseInfantProgramTask.class),
                 task(tenMinutes, oneHour, MarkBahmniAppointmentsAsCompleted.class)  // generally we want this to run after the close stale visits task

--- a/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
@@ -1,5 +1,6 @@
 package org.openmrs.module.pihcore.task;
 
+import org.apache.commons.lang.time.DateUtils;
 import org.apache.commons.lang.time.StopWatch;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.pihcore.SierraLeoneConfigConstants;
@@ -11,9 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -75,11 +73,9 @@ public class PihRemovePatientsFromMCOEQueue implements Runnable {
         criteria.setQueues(Collections.singletonList(queue));
         criteria.setIsEnded(false);
 
-        LocalDateTime now = LocalDateTime.now();
-        ZonedDateTime atZone = now.atZone(ZoneId.systemDefault());
-        Date currentTime = atZone.toInstant().toEpochMilli() > 0 ? Date.from(atZone.toInstant()) : new Date();
+        Date currentTime = new Date();
+        Date removalTimeLimit = DateUtils.addHours(currentTime, (int) (-1*QUEUE_TIMEOUT_HOURS));
 
-        Date removalTimeLimit = Date.from(atZone.minusHours(QUEUE_TIMEOUT_HOURS).toInstant());
         criteria.setStartedOnOrBefore(removalTimeLimit);
 
         List<QueueEntry> queueEntries = queueServices.getQueueEntryService().getQueueEntries(criteria);

--- a/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 
 public class PihRemovePatientsFromMCOEQueue implements Runnable {
 
-    private static final Long QUEUE_TIMEOUT_HOURS = 12L; // remove all queue entries from the MCOE Triage older than 12 hours
+    public static final Long QUEUE_TIMEOUT_HOURS = 12L; // remove all queue entries from the MCOE Triage older than 12 hours
     private final Logger log = LoggerFactory.getLogger(getClass());
     private static boolean isExecuting = false;
 

--- a/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
@@ -1,0 +1,106 @@
+package org.openmrs.module.pihcore.task;
+
+import org.apache.commons.lang.time.StopWatch;
+import org.openmrs.Concept;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.queue.api.QueueServicesWrapper;
+import org.openmrs.module.queue.api.search.QueueEntrySearchCriteria;
+import org.openmrs.module.queue.api.search.QueueSearchCriteria;
+import org.openmrs.module.queue.model.Queue;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+public class PihRemovePatientsFromMCOEQueue implements Runnable {
+
+    private static final Long QUEUE_TIMEOUT_MINUTES = 720L;
+    private static final String MCOE_TRIAGE_QUEUE_CONCEPT_CODE_PIH = "14976";
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static boolean isExecuting = false;
+
+    @Override
+    public void run() {
+
+        if (isExecuting) {
+            log.info("Not executing " + getClass() + " because another instance is already executing");
+            return;
+        }
+
+        isExecuting = true;
+
+        try {
+            log.info("Executing " + getClass());
+            StopWatch stopWatch = new StopWatch();
+            stopWatch.start();
+
+            Queue queue = getQueue();
+            if (queue == null) return;
+
+            int removedPatientsCount = removeTimedOutPatients(queue);
+
+            stopWatch.stop();
+            log.info("Execution completed in {} - {} patients removed", stopWatch, removedPatientsCount);
+        } catch (Exception e) {
+            log.error("Error executing " + getClass(), e);
+        } finally {
+            isExecuting = false;
+        }
+    }
+
+    private Queue getQueue() throws Exception {
+        Concept MCOE_TRIAGE_QUEUE_CONCEPT = Context.getConceptService().getConceptByMapping(MCOE_TRIAGE_QUEUE_CONCEPT_CODE_PIH, "PIH");
+        QueueSearchCriteria queueSearchCriteria = new QueueSearchCriteria();
+        queueSearchCriteria.setServices(Collections.singletonList(MCOE_TRIAGE_QUEUE_CONCEPT));
+
+        QueueServicesWrapper queueServices = Context.getRegisteredComponents(QueueServicesWrapper.class).get(0);
+        List<Queue> queues = queueServices.getQueueService().getQueues(queueSearchCriteria);
+
+        if (queues.isEmpty()) {
+            throw new Exception("No queue found with service concept " + MCOE_TRIAGE_QUEUE_CONCEPT_CODE_PIH);
+        }
+        if (queues.size() > 1) {
+            throw new Exception("Multiple queues found with service concept " + MCOE_TRIAGE_QUEUE_CONCEPT_CODE_PIH);
+        }
+
+        return queues.get(0);
+    }
+
+    private int removeTimedOutPatients(Queue queue) {
+        int numPatientsRemoved = 0;
+
+        QueueServicesWrapper queueServices = Context.getRegisteredComponents(QueueServicesWrapper.class).get(0);
+        QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();
+        criteria.setQueues(Collections.singletonList(queue));
+        criteria.setIsEnded(false);
+
+        List<QueueEntry> queueEntries = queueServices.getQueueEntryService().getQueueEntries(criteria);
+
+        if (queueEntries == null || queueEntries.isEmpty()) {
+            return numPatientsRemoved;
+        }
+
+        Date currentTime = new Date();
+
+        for (QueueEntry entry : queueEntries) {
+            Date startedAt = entry.getStartedAt();
+            long activeMinutes = Duration.between(startedAt.toInstant(), currentTime.toInstant()).toMinutes();
+
+            if (activeMinutes > QUEUE_TIMEOUT_MINUTES) {
+                log.warn("Removing patient {} from queue after {} minutes", entry.getPatient().getUuid(), activeMinutes);
+                entry.setEndedAt(currentTime);
+                queueServices.getQueueEntryService().saveQueueEntry(entry);
+
+                numPatientsRemoved++;
+            }
+        }
+
+        return numPatientsRemoved;
+    }
+}

--- a/api/src/test/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueueTest.java
+++ b/api/src/test/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueueTest.java
@@ -1,0 +1,71 @@
+package org.openmrs.module.pihcore.task;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.module.pihcore.PihCoreContextSensitiveTest;
+import org.openmrs.module.pihcore.SierraLeoneConfigConstants;
+import org.openmrs.module.queue.api.QueueEntryService;
+import org.openmrs.module.queue.api.QueueService;
+import org.openmrs.module.queue.api.search.QueueEntrySearchCriteria;
+import org.openmrs.module.queue.model.Queue;
+import org.openmrs.module.queue.model.QueueEntry;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PihRemovePatientsFromMCOEQueueTest extends PihCoreContextSensitiveTest {
+
+    @Autowired
+    @Qualifier("queue.QueueEntryService")
+    protected QueueEntryService queueEntryService;
+
+    @Autowired
+    @Qualifier("queue.QueueService")
+    protected QueueService queueService;
+
+    PihRemovePatientsFromMCOEQueue task;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        executeDataSet("mcoeTriageQueueTestDataset.xml");
+        task = new PihRemovePatientsFromMCOEQueue();
+    }
+    @Test
+    public void testGetMCOEQueue() {
+        Optional<Queue> mcoeQueue = queueService.getQueueByUuid(SierraLeoneConfigConstants.QUEUE_TRIAGE_UUID);
+        assertThat(mcoeQueue.isPresent(), org.hamcrest.Matchers.is(true));
+        assertThat(mcoeQueue.get().getName(), org.hamcrest.Matchers.is("MCOE Triage"));
+    }
+
+    @Test
+    public void shouldRemoveQueueEntriesOlderThanTwelfeHours() {
+        Optional<Queue> mcoeQueue = queueService.getQueueByUuid(SierraLeoneConfigConstants.QUEUE_TRIAGE_UUID);
+        assertThat(mcoeQueue.isPresent(), org.hamcrest.Matchers.is(true));
+        assertThat(mcoeQueue.get().getName(), org.hamcrest.Matchers.is("MCOE Triage"));
+
+        QueueEntrySearchCriteria criteria = new QueueEntrySearchCriteria();
+        criteria.setQueues(Collections.singletonList(mcoeQueue.get()));
+        criteria.setIsEnded(false);
+        LocalDateTime now = LocalDateTime.now();
+        ZonedDateTime atZone = now.atZone(ZoneId.systemDefault());
+        Date removalTimeLimit = Date.from(atZone.minusHours(PihRemovePatientsFromMCOEQueue.QUEUE_TIMEOUT_HOURS).toInstant());
+        criteria.setStartedOnOrBefore(removalTimeLimit);
+
+        List<QueueEntry> queueEntries = queueEntryService.getQueueEntries(criteria);
+        assertThat(queueEntries.size(), org.hamcrest.Matchers.is(1));
+
+        task.run();
+        queueEntries = queueEntryService.getQueueEntries(criteria);
+        assertThat(queueEntries.size(), org.hamcrest.Matchers.is(0));
+
+    }
+}

--- a/api/src/test/resources/mcoeTriageQueueTestDataset.xml
+++ b/api/src/test/resources/mcoeTriageQueueTestDataset.xml
@@ -1,0 +1,22 @@
+<dataset>
+
+    <location location_id="17" name="MCOE Triage" description="MCOE Triage" creator="1" date_created="2012-09-24 10:10:31.0" retired="false"  uuid="f85feffc-fe54-4648-aa14-01ed6d30b943"/>
+
+    <!--A concept set of queue priorities -->
+    <concept concept_id="1000" retired="false" is_set="true" creator="1" date_created="2022-02-02 14:31:00.0" uuid="897eba27-2b38-43e8-91a9-4dfe3956a35t"/>
+    <concept concept_id="1001" retired="false" is_set="false" creator="1" date_created="2022-02-02 14:40:00.0" uuid="90b910bd-298c-4ecf-a632-661ae2f446op"/>
+    <!-- Triage service-->
+    <concept concept_id="2001" retired="false" is_set="false" creator="1" date_created="2022-02-02 14:40:00.0" uuid="167411AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+    <!--A concept set of queue status -->
+    <concept concept_id="3000" retired="false" is_set="true" creator="1" date_created="2022-02-02 14:31:00.0" uuid="303eba27-2b38-43e8-91a9-4dfe3956a78t"/>
+    <concept concept_id="3001" retired="false" is_set="false" creator="1" date_created="2022-02-02 14:40:00.0" uuid="31b910bd-298c-4ecf-a632-661ae2f4460y"/>
+    <concept concept_id="3002" retired="false" is_set="false" creator="1" date_created="2022-02-02 14:40:00.0" uuid="56b910bd-298c-4ecf-a632-661ae2f7865y"/>
+
+    <!-- Queues -->
+    <queue queue_id="1" name="MCOE Triage" description="MCOE Triage queue" location_id="17" service="2001" creator="1"
+           date_created="2022-01-31 00:00:00.0" retired="false" uuid="3113f164-68f0-11ee-ab8d-0242ac120002"/>
+
+    <queue_entry queue_entry_id="1"  queue_id="1" patient_id="7" creator="1" priority="1001" status="3001" sort_weight="0"
+                 date_created="2022-02-02 16:38:56.0" started_at="2022-02-02 16:40:56.0" voided="false" uuid="4eb8fe43-2813-4kbc-80dc-2e5d30252cc6"/>
+
+</dataset>


### PR DESCRIPTION
@mseaton , please let me know if this is the right direction for removing timeout entries from the MCOE triage queue. I will add unit tests and more configuration if necessary? Thanks!