### PR TITLE
SL-1037: admit newborn to mother's inpatient location at current time…

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/htmlformentry/action/RegisterBabyAction.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/htmlformentry/action/RegisterBabyAction.java
@@ -84,7 +84,7 @@ public class RegisterBabyAction implements CustomFormSubmissionAction {
             Concept noConcept = Context.getConceptService().getConceptByMapping(NO_CONCEPT, "CIEL");
 
             Patient mother = formEntrySession.getPatient();
-            Encounter encounter = formEntrySession.getEncounter();
+            Encounter encounter = formEntrySession.getEncounter(); 
             HashMap<String, Obs> registeredBabies = new LinkedHashMap<>();
             for (Obs candidate : encounter.getObsAtTopLevel(false)) {
                 if (candidate.getConcept().equals(newbornDetailsConcept)) {
@@ -365,7 +365,8 @@ public class RegisterBabyAction implements CustomFormSubmissionAction {
         VisitDomainWrapper wrappedVisit = adtService.wrap(motherEncounter.getVisit());
         Location motherLocation = null;
         try {
-            motherLocation = wrappedVisit.getInpatientLocation(birthDatetime);
+            // get the mother's current inpatient location
+            motherLocation = wrappedVisit.getInpatientLocation(new Date());
         } catch (IllegalArgumentException e) {
             log.error(e);
         }


### PR DESCRIPTION
… instead of birth time

Testing done:
- Create mother, admit her to Labour and Delivery at T = 0 minutes, 
- At T = 2 minutes, transfer the mother to the Postnatal Ward, with a bed assigned
- Fill out Labour and Delivery Summary form to record a newborn, with birth time backdated to T = 1 minute
- Verify that the newborn is admitted to Postnatal Ward and assigned to same bed as the mother.