### PR TITLE
SL-983: one duplicate entry should not prevent removing other entries from the queue

### DIFF
--- a/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
@@ -91,12 +91,11 @@ public class PihRemovePatientsFromMCOEQueue implements Runnable {
             entry.setEndedAt(currentTime);
             try {
                 queueServices.getQueueEntryService().saveQueueEntry(entry);
+                log.warn("Removing patient {} from queue after {} minutes", entry.getPatient().getUuid(), activeMinutes);
+                numPatientsRemoved++;
             } catch (Exception e) {
                 log.error("Failed to remove patient: " + entry.getPatient().getUuid() + " from queue.", e);
-                continue;
             }
-            log.warn("Removing patient {} from queue after {} minutes", entry.getPatient().getUuid(), activeMinutes);
-            numPatientsRemoved++;
         }
 
         return numPatientsRemoved;

--- a/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
@@ -88,11 +88,15 @@ public class PihRemovePatientsFromMCOEQueue implements Runnable {
         for (QueueEntry entry : queueEntries) {
             Date startedAt = entry.getStartedAt();
             long activeMinutes = Duration.between(startedAt.toInstant(), currentTime.toInstant()).toMinutes();
-            log.warn("Removing patient {} from queue after {} minutes", entry.getPatient().getUuid(), activeMinutes);
             entry.setEndedAt(currentTime);
-            queueServices.getQueueEntryService().saveQueueEntry(entry);
+            try {
+                queueServices.getQueueEntryService().saveQueueEntry(entry);
+            } catch (Exception e) {
+                log.error("Failed to remove patient: " + entry.getPatient().getUuid() + " from queue.", e);
+                continue;
+            }
+            log.warn("Removing patient {} from queue after {} minutes", entry.getPatient().getUuid(), activeMinutes);
             numPatientsRemoved++;
-
         }
 
         return numPatientsRemoved;

--- a/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
+++ b/api/src/main/java/org/openmrs/module/pihcore/task/PihRemovePatientsFromMCOEQueue.java
@@ -91,7 +91,7 @@ public class PihRemovePatientsFromMCOEQueue implements Runnable {
             entry.setEndedAt(currentTime);
             try {
                 queueServices.getQueueEntryService().saveQueueEntry(entry);
-                log.warn("Removing patient {} from queue after {} minutes", entry.getPatient().getUuid(), activeMinutes);
+                log.warn("Removed patient {} from queue after {} minutes", entry.getPatient().getUuid(), activeMinutes);
                 numPatientsRemoved++;
             } catch (Exception e) {
                 log.error("Failed to remove patient: " + entry.getPatient().getUuid() + " from queue.", e);


### PR DESCRIPTION
@mseaton , this change would allow removing from the queue valid entries which are not duplicate. Maybe because of the previous bug addressed in https://openmrs.atlassian.net/browse/O3-4985 duplicate entries may be present in the queue and therefore the entire code below was not executing if the duplicate entry happened to be the first entry processed.  