### PR TITLE
SL-1334: add config parameter to limit the number of obs displayed

### DIFF
--- a/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/ObsByEncounterFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/ObsByEncounterFragmentController.java
@@ -118,8 +118,18 @@ public class ObsByEncounterFragmentController {
                 null,
                 false); //includeVoidedObs
 
+        Integer maxRecords = null;
+        String maxRecordsConfig = app.getConfig().get("maxRecords") != null ?  app.getConfig().get("maxRecords").getTextValue() : null;
+        if ( maxRecordsConfig != null ) {
+            maxRecords = Integer.parseInt(maxRecordsConfig.toString());
+        }
+
         Map<Encounter, List<Obs>> encounterObs = new HashMap<>();
+        int obsCount = 0;
         for (Obs obs : obsList) {
+            if (maxRecords != null && obsCount >= maxRecords) {
+                break;
+            }
             //group obs by encounter
             List<Obs> existingList = encounterObs.get(obs.getEncounter());
             if (existingList == null ) {
@@ -127,6 +137,7 @@ public class ObsByEncounterFragmentController {
             }
             existingList.add(obs);
             encounterObs.put(obs.getEncounter(), existingList);
+            obsCount++;
         }
         List<Encounter> encounters = new ArrayList<>(encounterObs.keySet());
         // order the encounters by encounterDatetime descending


### PR DESCRIPTION
@mogoodrich , I just added a new config parameter to limit the number of obs returned:
https://github.com/PIH/openmrs-config-pihsl/pull/307

Here is a snapshot before this change:
<img width="1197" height="861" alt="Screenshot 2026-05-11 at 4 01 18 PM" src="https://github.com/user-attachments/assets/5b04640a-25a5-43c3-9df4-75052c66b3c9" />

and after the new config param was introduced:

<img width="1197" height="861" alt="Screenshot 2026-05-11 at 4 28 29 PM" src="https://github.com/user-attachments/assets/2fbd22ec-d000-4e65-95ec-8db9d569eab8" />


