### PR TITLE
SL-873: fix bug when vaccinations was the last section

### DIFF
--- a/omod/src/main/webapp/resources/scripts/visit/visit.js
+++ b/omod/src/main/webapp/resources/scripts/visit/visit.js
@@ -752,8 +752,8 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
                                 loadPage(sections[redirectToSectionIdx].id);
                             }
                             else {
-                                // if there are any errors, just continue loading the page
-                                loadPage();
+                                // no further sections — return to the visit overview so the user gets a clear end-of-workflow signal
+                                loadPage("overview");
                             }
                         }
                     });


### PR DESCRIPTION
@lnball , @mogoodrich : 
The issue was with the loadPage() function which did nothing. 

https://github.com/user-attachments/assets/af389ba0-e34a-4765-aed9-972c245721eb



Here is the analysis and suggested fix. I will add more details to the JIRA ticket:
`Analysis of goToNextSection (visit.js:696–762)

  The function computes redirectToSectionIdx from nextSection/currentSection, then branches:

  1. Section has editUrl (line 723) → compile URL and emr.navigateTo to the form's edit page.
  2. No editUrl but still in bounds (line 751) → loadPage(sections[redirectToSectionIdx].id) — this is the vaccinations path (the section id matches the "vaccinations" ui-router state at
  line 19).
  3. Off the end of sections (line 754–757) → loadPage() with no argument.

  The bug when vaccinations is the last section

  When the user clicks Next from the vaccinations section:
  - currentSection = "vaccinations", so redirectToSectionIdx = sections.length
  - Both if (redirectToSectionIdx < sections.length) checks fail
  - Falls to bare loadPage() → switchToState(undefined) → switchToState no-ops on a falsy state (visit.js:765)
  - Result: nothing visible happens. The user gets no feedback and appears stuck on the vaccinations page.

  Recommendation

  Two complementary changes:

  1. In goToNextSection (line 754–757): when there is no next section, route back to the visit overview instead of calling loadPage() with no state — e.g. loadPage("overview"). The "overview"
   state is already registered (line 10) and is the natural "you're done with this workflow" landing spot. This gives the user a clear end-of-workflow signal and resets the breadcrumbs (the
  onEnter at line 14 already does this).`