### PR TITLE
SL-1292: add inborn status to dashboard widget

### DIFF
--- a/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/PatientLocationFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/PatientLocationFragmentController.java
@@ -65,18 +65,40 @@ public class PatientLocationFragmentController {
         model.put("patientStatus", inpatientLocation.get("patientStatus"));
         model.put("inpatientLocation", inpatientLocation.get("currentInpatientLocation"));
         model.put("queueName", inpatientLocation.get("queueName"));
-        model.put("admissionStatus", getAdmissionStatus(activeVisit, ui));
+        model.put("activeVisitUuid", activeVisit != null ? activeVisit.getVisit().getUuid() : null);
+        model.put("isBornDuringVisit", getBornDuringVisitValue(activeVisit));
+        model.put("visitAttributeUuid", getVisitAttributeUuid(activeVisit));
+        model.put("bornDuringVisitAttributeType", BORN_DURING_VISIT_ATTRIBUTE_TYPE);
     }
 
     /**
-     * Determines the admission status (inborn vs outborn) based on the "born during visit" attribute
+     * Gets the UUID of the "born during visit" visit attribute
      *
      * @param activeVisit the active visit wrapper, may be null
-     * @param ui the UI utils for message localization
-     * @return localized admission status message
+     * @return the visit attribute UUID, or null if not found
      */
-    private String getAdmissionStatus(VisitDomainWrapper activeVisit, UiUtils ui) {
-        String admissionStatus = ui.message("pihcore.outborn");
+    private String getVisitAttributeUuid(VisitDomainWrapper activeVisit) {
+        if (activeVisit != null && activeVisit.getVisit() != null) {
+            Visit visit = activeVisit.getVisit();
+            VisitAttributeType visitAttributeType = Context.getVisitService().getVisitAttributeTypeByUuid(BORN_DURING_VISIT_ATTRIBUTE_TYPE);
+            if (visitAttributeType != null) {
+                for (VisitAttribute attribute : visit.getActiveAttributes()) {
+                    if (attribute.getAttributeType().equals(visitAttributeType)) {
+                        return attribute.getUuid();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets the boolean value of the "born during visit" attribute
+     *
+     * @param activeVisit the active visit wrapper, may be null
+     * @return true if born during visit, false otherwise
+     */
+    private boolean getBornDuringVisitValue(VisitDomainWrapper activeVisit) {
         if (activeVisit != null && activeVisit.getVisit() != null) {
             Visit visit = activeVisit.getVisit();
             VisitAttributeType visitAttributeType = Context.getVisitService().getVisitAttributeTypeByUuid(BORN_DURING_VISIT_ATTRIBUTE_TYPE);
@@ -84,14 +106,15 @@ public class PatientLocationFragmentController {
                 for (VisitAttribute attribute : visit.getActiveAttributes()) {
                     if (attribute.getAttributeType().equals(visitAttributeType)) {
                         Object value = attribute.getValue();
-                        if (value != null && value instanceof Boolean && (Boolean)value == true) {
-                            admissionStatus = ui.message("pihcore.inborn");
+                        if (value != null && value instanceof Boolean) {
+                            return (Boolean)value;
                         }
                         break;
                     }
                 }
             }
         }
-        return admissionStatus;
+        return false;
     }
+
 }

--- a/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/PatientLocationFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/PatientLocationFragmentController.java
@@ -2,7 +2,12 @@ package org.openmrs.module.pihcore.fragment.controller.dashboardwidgets;
 
 
 import org.openmrs.Patient;
+import org.openmrs.Visit;
+import org.openmrs.VisitAttribute;
+import org.openmrs.VisitAttributeType;
 import org.openmrs.api.PatientService;
+import org.openmrs.api.VisitService;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.appframework.domain.AppDescriptor;
 import org.openmrs.module.appui.UiSessionContext;
 import org.openmrs.module.emrapi.adt.AdtService;
@@ -19,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PatientLocationFragmentController {
+    private static String BORN_DURING_VISIT_ATTRIBUTE_TYPE = "86f716fc-5e26-4eb1-9484-46370cff28f0";
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     public void controller(@SpringBean("patientService") PatientService patientService,
@@ -59,5 +65,33 @@ public class PatientLocationFragmentController {
         model.put("patientStatus", inpatientLocation.get("patientStatus"));
         model.put("inpatientLocation", inpatientLocation.get("currentInpatientLocation"));
         model.put("queueName", inpatientLocation.get("queueName"));
+        model.put("admissionStatus", getAdmissionStatus(activeVisit, ui));
+    }
+
+    /**
+     * Determines the admission status (inborn vs outborn) based on the "born during visit" attribute
+     *
+     * @param activeVisit the active visit wrapper, may be null
+     * @param ui the UI utils for message localization
+     * @return localized admission status message
+     */
+    private String getAdmissionStatus(VisitDomainWrapper activeVisit, UiUtils ui) {
+        String admissionStatus = ui.message("pihcore.outborn");
+        if (activeVisit != null && activeVisit.getVisit() != null) {
+            Visit visit = activeVisit.getVisit();
+            VisitAttributeType visitAttributeType = Context.getVisitService().getVisitAttributeTypeByUuid(BORN_DURING_VISIT_ATTRIBUTE_TYPE);
+            if (visitAttributeType != null) {
+                for (VisitAttribute attribute : visit.getActiveAttributes()) {
+                    if (attribute.getAttributeType().equals(visitAttributeType)) {
+                        Object value = attribute.getValue();
+                        if (value != null && value instanceof Boolean && (Boolean)value == true) {
+                            admissionStatus = ui.message("pihcore.inborn");
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        return admissionStatus;
     }
 }

--- a/omod/src/main/webapp/fragments/dashboardwidgets/patientLocation.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/patientLocation.gsp
@@ -1,3 +1,8 @@
+<style>
+    .boldLabel {
+        font-family: 'OpenSansBold';
+    }
+</style>
 <% if (patientStatus.length() > 0 ) { %>
     <div class="info-section patient-location ${app.id}">
         <div class="info-header">
@@ -7,7 +12,7 @@
         <div class="info-body">
             <div>
                 <% if (inpatientLocation != null ) { %>
-                    <span class="patient-dashboard-widget-label">${ ui.message("pihcore.current.location") }:</span>
+                    <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.current.location") }:</span>
                     <span class="patient-dashboard-widget-value">
                         <% if (inpatientLocation.id == sessionContext.sessionLocationId) { %>
                             <a href="/${contextPath}/spa/home/ward">${ui.format(inpatientLocation)}</a>
@@ -16,13 +21,17 @@
                         <% } %>
                     </span>
                 <% } else { %>
-                    <span class="patient-dashboard-widget-label">${ ui.message("pihcore.queue.name") }:</span>
+                    <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.queue.name") }:</span>
                     <span class="patient-dashboard-widget-value">${queueName}</span>
                 <% } %>
             </div>
             <div>
-                <span class="patient-dashboard-widget-label">${ ui.message("pihcore.status") }:</span>
+                <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.status") }:</span>
                 <span class="patient-dashboard-widget-value">${patientStatus}</span>
+            </div>
+            <div>
+                <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.admission.type") }:</span>
+                <span class="patient-dashboard-widget-value">${ admissionStatus }</span>
             </div>
         </div>
     </div>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/patientLocation.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/patientLocation.gsp
@@ -1,38 +1,158 @@
 <style>
-    .boldLabel {
-        font-family: 'OpenSansBold';
-    }
+.boldLabel {
+    font-family: 'OpenSansBold';
+}
+.edit-icon {
+    cursor: pointer;
+    margin-left: 5px;
+    color: #007bff;
+}
+.edit-icon:hover {
+    color: #0056b3;
+}
+.admission-status-editor {
+    display: inline-block;
+    margin-left: 10px;
+}
+.admission-status-editor select {
+    padding: 4px 8px;
+    margin-right: 5px;
+}
+.admission-status-save-btn {
+    background-color: #dc3545;
+    color: white;
+    border: none;
+    padding: 4px 12px;
+    cursor: pointer;
+    border-radius: 3px;
+}
+.admission-status-save-btn:hover {
+    background-color: #c82333;
+}
+.admission-status-save-btn:disabled {
+    background-color: #6c757d;
+    cursor: not-allowed;
+}
 </style>
+
 <% if (patientStatus.length() > 0 ) { %>
-    <div class="info-section patient-location ${app.id}">
-        <div class="info-header">
-            <i class="icon-map-marker"></i>
-            <h3>${ ui.message("pihcore.patientLocation.ucase") }</h3>
-        </div>
-        <div class="info-body">
-            <div>
-                <% if (inpatientLocation != null ) { %>
-                    <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.current.location") }:</span>
-                    <span class="patient-dashboard-widget-value">
-                        <% if (inpatientLocation.id == sessionContext.sessionLocationId) { %>
-                            <a href="/${contextPath}/spa/home/ward">${ui.format(inpatientLocation)}</a>
-                        <% } else { %>
-                            ${ui.format(inpatientLocation)}
-                        <% } %>
-                    </span>
+<div class="info-section patient-location ${app.id}">
+    <div class="info-header">
+        <i class="icon-map-marker"></i>
+        <h3>${ ui.message("pihcore.patientLocation.ucase") }</h3>
+    </div>
+    <div class="info-body">
+        <div>
+            <% if (inpatientLocation != null ) { %>
+            <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.current.location") }:</span>
+            <span class="patient-dashboard-widget-value">
+                <% if (inpatientLocation.id == sessionContext.sessionLocationId) { %>
+                <a href="/${contextPath}/spa/home/ward">${ui.format(inpatientLocation)}</a>
                 <% } else { %>
-                    <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.queue.name") }:</span>
-                    <span class="patient-dashboard-widget-value">${queueName}</span>
+                ${ui.format(inpatientLocation)}
                 <% } %>
-            </div>
-            <div>
-                <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.status") }:</span>
-                <span class="patient-dashboard-widget-value">${patientStatus}</span>
-            </div>
-            <div>
-                <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.admission.type") }:</span>
-                <span class="patient-dashboard-widget-value">${ admissionStatus }</span>
-            </div>
+            </span>
+            <% } else { %>
+            <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.queue.name") }:</span>
+            <span class="patient-dashboard-widget-value">${queueName}</span>
+            <% } %>
+        </div>
+        <div>
+            <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.status") }:</span>
+            <span class="patient-dashboard-widget-value">${patientStatus}</span>
+        </div>
+        <div>
+            <span class="patient-dashboard-widget-label boldLabel">${ ui.message("pihcore.admission.type") }:</span>
+            <span class="patient-dashboard-widget-value">
+                <span id="admissionStatusDisplay">${ isBornDuringVisit ? ui.message("pihcore.inborn") : ui.message("pihcore.outborn") }</span>
+                <% if (activeVisitUuid != null && visitAttributeUuid != null) { %>
+                <i class="icon-pencil edit-icon" id="editAdmissionStatusIcon" onclick="showAdmissionStatusEditor()" title="${ ui.message("coreapps.edit") }"></i>
+                <span id="admissionStatusEditor" class="admission-status-editor" style="display: none;">
+                    <select id="admissionStatusSelect">
+                        <option value="true" ${ isBornDuringVisit ? 'selected' : '' }>${ ui.message("pihcore.inborn") }</option>
+                        <option value="false" ${ !isBornDuringVisit ? 'selected' : '' }>${ ui.message("pihcore.outborn") }</option>
+                    </select>
+                    <button class="admission-status-save-btn" onclick="saveAdmissionStatus()">${ ui.message("coreapps.save") }</button>
+                </span>
+                <% } %>
+            </span>
         </div>
     </div>
+</div>
+
+<script type="text/javascript">
+    var ACTIVE_VISIT_UUID = '${ activeVisitUuid }';
+    var VISIT_ATTRIBUTE_UUID = '${ visitAttributeUuid }';
+    var ATTRIBUTE_TYPE_UUID = '86f716fc-5e26-4eb1-9484-46370cff28f0';
+    var INBORN_LABEL = '${ ui.message("pihcore.inborn") }';
+    var OUTBORN_LABEL = '${ ui.message("pihcore.outborn") }';
+
+    function showAdmissionStatusEditor() {
+        jq('#editAdmissionStatusIcon').hide();
+        jq('#admissionStatusEditor').show();
+    }
+
+    function hideAdmissionStatusEditor() {
+        jq('#editAdmissionStatusIcon').show();
+        jq('#admissionStatusEditor').hide();
+    }
+
+    function saveAdmissionStatus() {
+        var bornDuringVisit = jq('#admissionStatusSelect').val() === 'true';
+        var saveButton = jq('.admission-status-save-btn');
+
+        // Disable button during save
+        saveButton.prop('disabled', true);
+        saveButton.text('${ ui.message("coreapps.saving") }');
+
+        var requestData = {
+            attributeType: ATTRIBUTE_TYPE_UUID,
+            value: bornDuringVisit
+        };
+
+        jq.ajax({
+            url: '/' + OPENMRS_CONTEXT_PATH + '/ws/rest/v1/visit/' + ACTIVE_VISIT_UUID + '/attribute/' + VISIT_ATTRIBUTE_UUID,
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify(requestData),
+            dataType: 'json',
+            success: function(response) {
+                // Update the display text
+                var displayText = bornDuringVisit ? INBORN_LABEL : OUTBORN_LABEL;
+                jq('#admissionStatusDisplay').text(displayText);
+                emr.successMessage('${ ui.message("pihcore.admission.type.success") }', 3000, 'top', 'right');
+
+                // Hide editor and show edit icon
+                hideAdmissionStatusEditor();
+
+                // Re-enable button
+                saveButton.prop('disabled', false);
+                saveButton.text('${ ui.message("coreapps.save") }');
+            },
+            error: function(xhr, status, error) {
+                console.error('Error updating admission status:', error);
+                emr.errorMessage('${ ui.message("pihcore.admission.type.fail") }', 3000, 'top', 'right');
+
+                // Re-enable button
+                saveButton.prop('disabled', false);
+                saveButton.text('${ ui.message("coreapps.save") }');
+            }
+        });
+    }
+
+    // Close editor when clicking outside
+    jq(document).on('click', function(event) {
+        var editor = jq('#admissionStatusEditor');
+        var icon = jq('#editAdmissionStatusIcon');
+
+        if (editor.is(':visible')) {
+            var isClickInside = editor.is(event.target) || editor.has(event.target).length > 0 ||
+                icon.is(event.target) || icon.has(event.target).length > 0;
+
+            if (!isClickInside) {
+                hideAdmissionStatusEditor();
+            }
+        }
+    });
+</script>
 <% } %>

--- a/omod/src/main/webapp/fragments/dashboardwidgets/patientLocation.gsp
+++ b/omod/src/main/webapp/fragments/dashboardwidgets/patientLocation.gsp
@@ -1,38 +1,40 @@
 <style>
-.boldLabel {
-    font-family: 'OpenSansBold';
-}
-.edit-icon {
-    cursor: pointer;
-    margin-left: 5px;
-    color: #007bff;
-}
-.edit-icon:hover {
-    color: #0056b3;
-}
-.admission-status-editor {
-    display: inline-block;
-    margin-left: 10px;
-}
-.admission-status-editor select {
-    padding: 4px 8px;
-    margin-right: 5px;
-}
-.admission-status-save-btn {
-    background-color: #dc3545;
-    color: white;
-    border: none;
-    padding: 4px 12px;
-    cursor: pointer;
-    border-radius: 3px;
-}
-.admission-status-save-btn:hover {
-    background-color: #c82333;
-}
-.admission-status-save-btn:disabled {
-    background-color: #6c757d;
-    cursor: not-allowed;
-}
+    .boldLabel {
+        font-family: 'OpenSansBold';
+    }
+    .edit-icon {
+        cursor: pointer;
+        margin-left: 5px;
+        color: #007bff;
+    }
+    .edit-icon:hover {
+        color: #0056b3;
+    }
+    .admission-status-editor {
+        display: inline-block;
+        margin-left: 10px;
+    }
+    .admission-status-editor select {
+        padding: 4px 8px;
+        margin-right: 5px;
+    }
+    .admission-status-save-btn {
+        background-color: #6c757d;
+        color: white;
+        border: none;
+        padding: 4px 12px;
+        cursor: pointer;
+        border-radius: 3px;
+    }
+    #admissionStatusSaveBtn.changed,
+    #admissionStatusSaveBtn.changed:hover {
+        background-color: #dc3545;
+    }
+
+    .admission-status-save-btn:disabled {
+        background-color: #6c757d;
+        cursor: not-allowed;
+    }
 </style>
 
 <% if (patientStatus.length() > 0 ) { %>
@@ -72,7 +74,7 @@
                         <option value="true" ${ isBornDuringVisit ? 'selected' : '' }>${ ui.message("pihcore.inborn") }</option>
                         <option value="false" ${ !isBornDuringVisit ? 'selected' : '' }>${ ui.message("pihcore.outborn") }</option>
                     </select>
-                    <button class="admission-status-save-btn" onclick="saveAdmissionStatus()">${ ui.message("coreapps.save") }</button>
+                    <button id="admissionStatusSaveBtn" class="admission-status-save-btn" onclick="saveAdmissionStatus()">${ ui.message("coreapps.save") }</button>
                 </span>
                 <% } %>
             </span>
@@ -86,24 +88,33 @@
     var ATTRIBUTE_TYPE_UUID = '86f716fc-5e26-4eb1-9484-46370cff28f0';
     var INBORN_LABEL = '${ ui.message("pihcore.inborn") }';
     var OUTBORN_LABEL = '${ ui.message("pihcore.outborn") }';
+    var INITIAL_VALUE = '${ isBornDuringVisit }';
 
     function showAdmissionStatusEditor() {
+        jq('#admissionStatusDisplay').hide();
         jq('#editAdmissionStatusIcon').hide();
         jq('#admissionStatusEditor').show();
     }
 
     function hideAdmissionStatusEditor() {
+        jq('#admissionStatusDisplay').show();
         jq('#editAdmissionStatusIcon').show();
         jq('#admissionStatusEditor').hide();
+        // Reset select to initial value
+        jq('#admissionStatusSelect').val(INITIAL_VALUE);
+        var saveButton = jq('#admissionStatusSaveBtn');
+        saveButton.removeClass('changed');
+        saveButton[0].style.removeProperty('background-color');
+        saveButton[0].style.removeProperty('background-image');
     }
 
     function saveAdmissionStatus() {
         var bornDuringVisit = jq('#admissionStatusSelect').val() === 'true';
-        var saveButton = jq('.admission-status-save-btn');
+        var saveButton = jq('#admissionStatusSaveBtn');
 
         // Disable button during save
         saveButton.prop('disabled', true);
-        saveButton.text('${ ui.message("coreapps.saving") }');
+        saveButton.text('${ ui.message("pihcore.saving") }');
 
         var requestData = {
             attributeType: ATTRIBUTE_TYPE_UUID,
@@ -121,7 +132,8 @@
                 var displayText = bornDuringVisit ? INBORN_LABEL : OUTBORN_LABEL;
                 jq('#admissionStatusDisplay').text(displayText);
                 emr.successMessage('${ ui.message("pihcore.admission.type.success") }', 3000, 'top', 'right');
-
+                // Update initial value
+                INITIAL_VALUE = bornDuringVisit.toString();
                 // Hide editor and show edit icon
                 hideAdmissionStatusEditor();
 
@@ -140,6 +152,21 @@
         });
     }
 
+    // Handle select change event
+    jq(document).on('change', '#admissionStatusSelect', function() {
+        var saveButton = jq('#admissionStatusSaveBtn');
+        var btnEl = saveButton[0];
+        if (jq(this).val() !== INITIAL_VALUE) {
+            saveButton.prop('disabled', false);
+            saveButton.addClass('changed');
+            btnEl.style.setProperty('background-color', '#dc3545', 'important');
+            btnEl.style.setProperty('background-image', 'none', 'important');
+        } else {
+            saveButton.removeClass('changed');
+            btnEl.style.removeProperty('background-color');
+            btnEl.style.removeProperty('background-image');
+        }
+    });
     // Close editor when clicking outside
     jq(document).on('click', function(event) {
         var editor = jq('#admissionStatusEditor');


### PR DESCRIPTION
Just adding the visit attribute inborn value to the dashboard widget:

<img width="1331" height="980" alt="Screenshot 2026-05-27 at 1 47 07 PM" src="https://github.com/user-attachments/assets/675578ad-094a-4e29-b735-7c8414545978" />


<img width="1331" height="980" alt="Screenshot 2026-05-27 at 1 47 32 PM" src="https://github.com/user-attachments/assets/83c29bf8-5c4a-4ee5-8c38-c1787681f171" />
