### PR TITLE
UHM-9280: Optimize queries for concepts in LabResultsFragmentController

### DIFF
--- a/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/LabResultsFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/LabResultsFragmentController.java
@@ -150,7 +150,7 @@ public class LabResultsFragmentController {
 
         while (!frontier.isEmpty()) {
             List<Concept> concepts = conceptService.getConcepts(
-                    new ConceptSearchCriteriaBuilder().addUuids(frontier.toArray(new String[0])).build());
+                    new ConceptSearchCriteriaBuilder().addUuids(frontier.toArray(new String[0])).includeRetired(true).build());
 
             visited.addAll(frontier);
             frontier.clear();

--- a/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/LabResultsFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/LabResultsFragmentController.java
@@ -13,6 +13,7 @@ import org.openmrs.api.EncounterService;
 import org.openmrs.api.PatientService;
 import org.openmrs.module.appframework.domain.AppDescriptor;
 import org.openmrs.module.emrapi.patient.PatientDomainWrapper;
+import org.openmrs.parameter.ConceptSearchCriteriaBuilder;
 import org.openmrs.parameter.EncounterSearchCriteriaBuilder;
 import org.openmrs.ui.framework.UiUtils;
 import org.openmrs.ui.framework.annotation.FragmentParam;
@@ -138,36 +139,28 @@ public class LabResultsFragmentController {
     }
 
     private Set<String> getLabCategoriesList(String labCategoriesSet, ConceptService conceptService) {
-        return getLabCategoriesListRecursive(labCategoriesSet, conceptService, new HashSet<>());
-    }
-
-    /**
-     * Recursive function that builds a set of Lab concepts.
-     * **Early return**: Stops immediately when the concept has already visited
-     * @param labCategoriesSet a String representing a concept set UUID
-     * @param conceptService
-     * @param visited a Set of concept set UUIDs that have already been visited to prevent cycles and redundant processing
-     * @return a Set of concept UUIDs
-     */
-
-    private Set<String> getLabCategoriesListRecursive(String labCategoriesSet, ConceptService conceptService, Set<String> visited) {
         Set<String> labCategories = new HashSet<>();
+        if (StringUtils.isBlank(labCategoriesSet)) {
+            return labCategories;
+        }
 
-        if (StringUtils.isNotBlank(labCategoriesSet)) {
-            // Check if already visited (prevents cycles and redundant processing)
-            if (visited.contains(labCategoriesSet)) {
-                return labCategories;
-            }
+        Set<String> visited = new HashSet<>();
+        Set<String> frontier = new HashSet<>();
+        frontier.add(labCategoriesSet);
 
-            visited.add(labCategoriesSet);
+        while (!frontier.isEmpty()) {
+            List<Concept> concepts = conceptService.getConcepts(
+                    new ConceptSearchCriteriaBuilder().addUuids(frontier.toArray(new String[0])).build());
 
-            Concept conceptSet = conceptService.getConceptByUuid(labCategoriesSet);
-            if (conceptSet != null) {
-                labCategories.add(conceptSet.getUuid());
+            visited.addAll(frontier);
+            frontier.clear();
 
-                if (conceptSet.getSetMembers().size() > 0) {
-                    for (Concept member : conceptSet.getSetMembers()) {
-                        labCategories.addAll(getLabCategoriesListRecursive(member.getUuid(), conceptService, visited));
+            for (Concept concept : concepts) {
+                labCategories.add(concept.getUuid());
+                for (Concept member : concept.getSetMembers()) {
+                    String memberUuid = member.getUuid();
+                    if (!visited.contains(memberUuid)) {
+                        frontier.add(memberUuid);
                     }
                 }
             }

--- a/omod/src/test/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/LabResultsFragmentControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/pihcore/fragment/controller/dashboardwidgets/LabResultsFragmentControllerTest.java
@@ -5,15 +5,20 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.openmrs.Concept;
 import org.openmrs.api.ConceptService;
+import org.openmrs.parameter.ConceptSearchCriteria;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -26,75 +31,101 @@ import static org.mockito.Mockito.when;
 public class LabResultsFragmentControllerTest {
 
     @SuppressWarnings("unchecked")
-    private Set<String> invokeGetLabCategoriesListRecursive(LabResultsFragmentController controller,
+    private Set<String> invokeGetLabCategoriesList(LabResultsFragmentController controller,
                                                             String labCategoriesSet,
-                                                            ConceptService conceptService,
-                                                            Set<String> visited) throws Exception {
+                                                            ConceptService conceptService) throws Exception {
         Method m = LabResultsFragmentController.class.getDeclaredMethod(
-                "getLabCategoriesListRecursive", String.class, ConceptService.class, Set.class);
+                "getLabCategoriesList", String.class, ConceptService.class);
         m.setAccessible(true);
-        return (Set<String>) m.invoke(controller, labCategoriesSet, conceptService, visited);
+        return (Set<String>) m.invoke(controller, labCategoriesSet, conceptService);
     }
 
     @Test
-    public void getLabCategoriesListRecursive_shouldReturnEmptySet_whenInputBlank() throws Exception {
+    public void getLabCategoriesList_shouldReturnEmptySet_whenInputBlank() throws Exception {
         LabResultsFragmentController controller = new LabResultsFragmentController();
         ConceptService conceptService = mock(ConceptService.class);
 
-        Set<String> result = invokeGetLabCategoriesListRecursive(controller, "   ", conceptService, new HashSet<String>());
+        Set<String> result = invokeGetLabCategoriesList(controller, "   ", conceptService);
 
         assertEquals(Collections.<String>emptySet(), result);
         verifyNoInteractions(conceptService);
     }
 
     @Test
-    public void getLabCategoriesListRecursive_shouldReturnEmptySet_whenConceptNotFound() throws Exception {
+    public void getLabCategoriesList_shouldReturnEmptySet_whenConceptNotFound() throws Exception {
         LabResultsFragmentController controller = new LabResultsFragmentController();
         ConceptService conceptService = mock(ConceptService.class);
 
-        when(conceptService.getConceptByUuid("set-uuid")).thenReturn(null);
+        when(conceptService.getConcepts(any(ConceptSearchCriteria.class))).thenReturn(Collections.emptyList());
 
-        Set<String> result = invokeGetLabCategoriesListRecursive(controller, "set-uuid", conceptService, new HashSet<String>());
+        Set<String> result = invokeGetLabCategoriesList(controller, "set-uuid", conceptService);
 
         assertEquals(Collections.<String>emptySet(), result);
-        verify(conceptService, times(1)).getConceptByUuid("set-uuid");
+        verify(conceptService, times(1)).getConcepts(any(ConceptSearchCriteria.class));
         verifyNoMoreInteractions(conceptService);
     }
 
     @Test
-    public void getLabCategoriesListRecursive_shouldCollectAllUuids_inTree() throws Exception {
+    public void getLabCategoriesList_shouldCollectAllUuids_inTree() throws Exception {
         LabResultsFragmentController controller = new LabResultsFragmentController();
         ConceptService conceptService = mock(ConceptService.class);
 
+        /*
+         * root
+         * |- child1
+         *   |- grandChild1
+         *   |- grandChild2
+         * |- child2
+         */
         Concept root = mock(Concept.class);
         Concept child1 = mock(Concept.class);
         Concept child2 = mock(Concept.class);
+        Concept grandChild1 = mock(Concept.class);
+        Concept grandChild2 = mock(Concept.class);
 
         when(root.getUuid()).thenReturn("root");
         when(child1.getUuid()).thenReturn("child1");
         when(child2.getUuid()).thenReturn("child2");
+        when(grandChild1.getUuid()).thenReturn("grandChild1");
+        when(grandChild2.getUuid()).thenReturn("grandChild2");
 
         when(root.getSetMembers()).thenReturn(Arrays.asList(child1, child2));
-        when(child1.getSetMembers()).thenReturn(Collections.emptyList());
+        when(child1.getSetMembers()).thenReturn(Arrays.asList(grandChild1, grandChild2));
         when(child2.getSetMembers()).thenReturn(Collections.emptyList());
+        when(grandChild1.getSetMembers()).thenReturn(Collections.emptyList());
+        when(grandChild2.getSetMembers()).thenReturn(Collections.emptyList());
 
-        when(conceptService.getConceptByUuid("root")).thenReturn(root);
-        when(conceptService.getConceptByUuid("child1")).thenReturn(child1);
-        when(conceptService.getConceptByUuid("child2")).thenReturn(child2);
+        Map<String, Concept> conceptMap = new HashMap<>();
+        conceptMap.put("root", root);
+        conceptMap.put("child1", child1);
+        conceptMap.put("child2", child2);
+        conceptMap.put("grandChild1", grandChild1);
+        conceptMap.put("grandChild2", grandChild2);
 
-        Set<String> result = invokeGetLabCategoriesListRecursive(controller, "root", conceptService, new HashSet<String>());
+        when(conceptService.getConcepts(any(ConceptSearchCriteria.class))).thenAnswer(inv -> {
+            ConceptSearchCriteria criteria = inv.getArgument(0);
+            ArrayList<Concept> result = new ArrayList<>();
+            for(String uuid : criteria.getUuids()) {
+                Concept c = conceptMap.get(uuid);
+                if(c != null) {
+                    result.add(c);
+                }
+            }
+            return result;
+        });
 
-        Set<String> expected = new HashSet<String>(Arrays.asList("root", "child1", "child2"));
+        Set<String> result = invokeGetLabCategoriesList(controller, "root", conceptService);
+
+        Set<String> expected = new HashSet<>(Arrays.asList("root", "child1", "child2", "grandChild1", "grandChild2"));
         assertEquals(expected, result);
 
-        verify(conceptService, times(1)).getConceptByUuid("root");
-        verify(conceptService, times(1)).getConceptByUuid("child1");
-        verify(conceptService, times(1)).getConceptByUuid("child2");
+        // BFS makes 3 batched calls: {root}, {child1,child2}, {grandChild1,grandChild2}
+        verify(conceptService, times(3)).getConcepts(any(ConceptSearchCriteria.class));
         verifyNoMoreInteractions(conceptService);
     }
 
     @Test
-    public void getLabCategoriesListRecursive_shouldHandleCycles_withoutInfiniteRecursion() throws Exception {
+    public void getLabCategoriesList_shouldHandleCycles_withoutInfiniteLoop() throws Exception {
         LabResultsFragmentController controller = new LabResultsFragmentController();
         ConceptService conceptService = mock(ConceptService.class);
 
@@ -108,17 +139,25 @@ public class LabResultsFragmentControllerTest {
         when(a.getSetMembers()).thenReturn(Collections.singletonList(b));
         when(b.getSetMembers()).thenReturn(Collections.singletonList(a));
 
-        when(conceptService.getConceptByUuid("A")).thenReturn(a);
-        when(conceptService.getConceptByUuid("B")).thenReturn(b);
+        Map<String, Concept> conceptMap = new HashMap<>();
+        conceptMap.put("A", a);
+        conceptMap.put("B", b);
 
-        Set<String> result = invokeGetLabCategoriesListRecursive(controller, "A", conceptService, new HashSet<String>());
+        when(conceptService.getConcepts(any(ConceptSearchCriteria.class))).thenAnswer(inv -> {
+            ConceptSearchCriteria criteria = inv.getArgument(0);
+            return criteria.getUuids().stream()
+                    .filter(conceptMap::containsKey)
+                    .map(conceptMap::get)
+                    .collect(Collectors.toList());
+        });
 
-        Set<String> expected = new HashSet<String>(Arrays.asList("A", "B"));
+        Set<String> result = invokeGetLabCategoriesList(controller, "A", conceptService);
+
+        Set<String> expected = new HashSet<>(Arrays.asList("A", "B"));
         assertEquals(expected, result);
 
-        // Each concept UUID should be looked up once due to the visited-set early return
-        verify(conceptService, times(1)).getConceptByUuid("A");
-        verify(conceptService, times(1)).getConceptByUuid("B");
+        // BFS makes 2 batched calls: {A}, then {B} — A is already visited so loop ends
+        verify(conceptService, times(2)).getConcepts(any(ConceptSearchCriteria.class));
         verifyNoMoreInteractions(conceptService);
     }
 }


### PR DESCRIPTION
Reimplement the `getLabCategoriesList()` function so that when we traverse through the concept hierarchy of he `labCategoriesSet`, we batch the queries for concepts by uuids at each depth level. 

I had Claude code reviewed this and it mentioned that the old code includes retired concepts. That was probably unintended, so I didn't do that here. If that's not the case I can change the `ConceptSearchCriteriaBuilder` to call `includeRetired(true)`