### PR TITLE
SL-1322: automatically print after the form loads in the view mode

### DIFF
--- a/omod/src/main/webapp/pages/visit/templates/encounters/defaultEncounterActions.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/encounters/defaultEncounterActions.gsp
@@ -1,6 +1,6 @@
+<a class="print-form-encounter" ng-show="canPrintForm()" ng-click="printForm()" title="${ ui.message('pihcore.visitNote.printForm') }"><i class="icon-print"></i></a>
 <a class="expand-encounter" ng-show="canExpand()" ng-click="expand()"><i class="icon-caret-right"></i></a>
 <a class="contract-encounter" ng-show="canContract()" ng-click="contract()"><i class="icon-caret-down"></i></a>
 <a class="view-encounter" ng-show="canView()" ng-click="view()"><i class="icon-caret-right"></i></a>
 <a class="edit-encounter" ng-show="canEdit()" ng-click="edit()"><i class="icon-pencil"></i></a>
 <a class="delete-encounter" ng-show="canDelete()" ng-click="delete()"><i class="icon-remove"></i></a>
-<a class="print-form-encounter" ng-show="canPrintForm()" ng-click="printForm()" title="${ ui.message('pihcore.visitNote.printForm') }"><i class="icon-print"></i></a>

--- a/omod/src/main/webapp/pages/visit/templates/encounters/printForm.gsp
+++ b/omod/src/main/webapp/pages/visit/templates/encounters/printForm.gsp
@@ -1,0 +1,11 @@
+<div class="dialog-header print-form-dialog-header">
+    <h3>{{ encounterTitle }}</h3>
+</div>
+<div class="dialog-content">
+    <!-- the form's HFE "view" html is injected here so the orderWidget scripts run and the medications/images render before printing -->
+    <div class="print-form-content"></div>
+    <div class="print-form-buttons">
+        <button class="confirm right" ng-click="doPrint()" ng-disabled="!printFormReady">${ ui.message("pihcore.print") }</button>
+        <button class="cancel" ng-click="closeThisDialog()">${ ui.message("uicommons.cancel") }</button>
+    </div>
+</div>

--- a/omod/src/main/webapp/resources/scripts/visit/visit.js
+++ b/omod/src/main/webapp/resources/scripts/visit/visit.js
@@ -110,8 +110,8 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
         }
     }])
 
-    .directive("encounter", [ "Encounter", "Concepts", "OrderTypes", "EncounterRoles", "DatetimeFormats", "SessionInfo", "EncounterTypeConfig", "$http", "$sce", "$filter",
-        function(Encounter, Concepts, OrderTypes, EncounterRoles, DatetimeFormats, SessionInfo, EncounterTypeConfig, $http, $sce, $filter) {
+    .directive("encounter", [ "Encounter", "Concepts", "OrderTypes", "EncounterRoles", "DatetimeFormats", "SessionInfo", "EncounterTypeConfig", "$http", "$sce", "$filter", "ngDialog", "$timeout",
+        function(Encounter, Concepts, OrderTypes, EncounterRoles, DatetimeFormats, SessionInfo, EncounterTypeConfig, $http, $sce, $filter, ngDialog, $timeout) {
             return {
                 restrict: "E",
                 scope: {
@@ -352,15 +352,65 @@ angular.module("visit", [ "filters", "constants", "encounterTypeConfig", "visitS
                         return false;
                     }
 
+                    // Render the form's HFE "view" html inline in a dialog. Unlike a blank
+                    // print window, the page here has jQuery and the htmlformentry orderWidget
+                    // available, so injecting the html with jQuery.html() runs the embedded
+                    // "jQuery(function(){ orderWidget.initialize(...) })" scripts and the
+                    // medications (and form images) render. Once everything is displayed the
+                    // user prints the fully-rendered form from the dialog.
+                    function openPrintFormDialog(html) {
+                        var dialogScope = $scope.$new();
+                        dialogScope.printFormReady = false;
+                        dialogScope.encounterTitle = $scope.encounter.encounterType ? $scope.encounter.encounterType.display : '';
+
+                        var dialog = ngDialog.open({
+                            template: 'templates/encounters/printForm.page',
+                            className: 'ngdialog-theme-default print-form-dialog',
+                            scope: dialogScope
+                        });
+
+                        dialogScope.doPrint = function() {
+                            // the content has been written to a separate print window by the time
+                            // printDiv returns, so the dialog can be closed once printing starts.
+                            if (printDiv($('#' + dialog.id + ' .print-form-content').html())) {
+                                ngDialog.close(dialog.id);
+                            }
+                        };
+
+                        // the dialog template loads asynchronously, so wait for its content
+                        // container to exist, then inject the html. Using jQuery.html() runs
+                        // the embedded order-widget scripts so the medications render.
+                        var injectWhenReady = function() {
+                            var content = $('#' + dialog.id + ' .print-form-content');
+                            if (content.length === 0) {
+                                $timeout(injectWhenReady, 50);
+                                return;
+                            }
+                            // the default ngDialog theme vertically centers the modal via a large
+                            // top padding; shrink it so the (often tall) print form sits near the
+                            // top of the screen instead
+                            $('#' + dialog.id).css('padding-top', '20px');
+                            content.html(html);
+                            dialogScope.printFormReady = true;
+                            // automatically send the form to the printer once it is fully
+                            // rendered, so the user no longer has to click the Print button.
+                            // A short delay gives the embedded order-widget scripts time to
+                            // render the medications/images before printing. The Print button
+                            // remains available for re-printing.
+                            $timeout(dialogScope.doPrint, 500);
+                        };
+                        $timeout(injectWhenReady);
+                    }
+
                     $scope.printForm = function() {
-                        // fetch a fresh rendering of the encounter's form (the HFE html view) and print it
+                        // fetch a fresh rendering of the encounter's form (the HFE html view)
                         var url = Handlebars.compile($scope.printFormUrl())({
                             encounter: $scope.encounter
                         });
                         $http.get("/" + OPENMRS_CONTEXT_PATH + url)
                             .then(function (response) {
                                 var data = response.data && response.data.html ? response.data.html : response.data;
-                                printDiv(data);
+                                openPrintFormDialog(data);
                             });
                     }
 


### PR DESCRIPTION
@mseaton , I was able to automatically send the form to the printer after it gets loaded in the view mode:

<img width="1449" height="898" alt="Screenshot 2026-06-22 at 3 17 00 PM" src="https://github.com/user-attachments/assets/11687a4a-1843-49c8-9c8a-7a3e2ea7bd6f" />

Please let me know if this looks like the right direction before I go and implement the rest of the formatting requested by the SL team.