### PR TITLE
UHM-9418 - Bump labworkflow OWA to 2.0.0-SNAPSHOT, migrate its obs data

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -1184,5 +1184,19 @@
         <dropTable tableName="dbevent_patient"/>
     </changeSet>
 
+    <changeSet id="20260730-migrate-labworkflow-obs-to-form-namespace-and-path" author="mseaton">
+        <comment>
+            UHM-9418 - Migrate lab workflow result-entry-form obs from comment to formNamespaceAndPath
+        </comment>
+        <sql>
+            update obs
+               set form_namespace_and_path = concat('labworkflow^result-entry-form/',
+                                                     replace(substring(comments, length('result-entry-form^') + 1), '^', '/')),
+                   comments = null
+             where comments like 'result-entry-form^%'
+               and (form_namespace_and_path is null or form_namespace_and_path = '');
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <idgenVersion>5.0.4</idgenVersion>
         <initializerVersion>2.12.0</initializerVersion>
         <labtrackingappVersion>1.3.0-SNAPSHOT</labtrackingappVersion>
-        <labworkflowOwaVersion>1.4.0-SNAPSHOT</labworkflowOwaVersion>
+        <labworkflowOwaVersion>2.0.0-SNAPSHOT</labworkflowOwaVersion>
         <legacyuiVersion>2.1.0</legacyuiVersion>
         <metadatamappingVersion>2.0.0</metadatamappingVersion>
         <namephoneticsVersion>1.19.0</namephoneticsVersion>


### PR DESCRIPTION
## Summary

The lab-result-entry OWA (`openmrs-owa-labworkflow` / `openmrs-react-components`) moved obs form/path tracking from `obs.comment` to `obs.formNamespaceAndPath` (breaking change — see [openmrs-react-components#281](https://github.com/openmrs/openmrs-react-components/pull/281) and [openmrs-owa-labworkflow#239](https://github.com/openmrs/openmrs-owa-labworkflow/pull/239)). This couples the two changes this module owns so they land and stay in sync in the same commit:

- Bumps `labworkflowOwaVersion` to `2.0.0-SNAPSHOT` in `pom.xml`.
- Adds a one-time liquibase changeset (`api/src/main/resources/liquibase.xml`) migrating historical `result-entry-form^...`-encoded `obs.comments` values into `obs.form_namespace_and_path`, clearing `comments` (previously repurposed for this tracking, now free for its actual clinical use).

**Not mergeable until `@openmrs/react-components@2.0.0` is actually published** (only pushed on its own PR branch so far) and `openmrs-owa-labworkflow`'s lockfile is regenerated against it — see the note on owa-labworkflow#239.

## Test plan

- [x] Liquibase changeset XML validated well-formed
- [x] SQL transform manually traced for both nested and single-segment `comments` values (exactly one `^` in the resulting `form_namespace_and_path`, matching the field's core constraint)
- [ ] Dry-run the migration's `SELECT` form against a production-shaped copy before deploy
- [ ] Merge only once react-components 2.0.0 is published and the labworkflow OWA branch is unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)